### PR TITLE
rollback changes using new spell list builder

### DIFF
--- a/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassAncientForest.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassAncientForest.cs
@@ -26,13 +26,73 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Subclasses
                 .SetGuiPresentation(Category.Feature)
                 .SetGuiPresentationNoContent()
                 .ClearSpells()
-                .SetSpellsAtLevel(1, Goodberry, Entangle)
-                .SetSpellsAtLevel(2, Barkskin, SpikeGrowth)
-                .SetSpellsAtLevel(3, MassHealingWord, VampiricTouch)
-                .SetSpellsAtLevel(4, Blight, GreaterRestoration)
-                .SetSpellsAtLevel(5, Contagion, RaiseDead)
-                .SetMaxSpellLevel()
+                //.SetSpellsAtLevel(0) // Warlock class has Cantrips so if we don't add this the spell list gets screwed
+                //.SetSpellsAtLevel(1, Goodberry, Entangle)
+                //.SetSpellsAtLevel(2, Barkskin, SpikeGrowth)
+                //.SetSpellsAtLevel(3, MassHealingWord, VampiricTouch)
+                //.SetSpellsAtLevel(4, Blight, GreaterRestoration)
+                //.SetSpellsAtLevel(5, Contagion, RaiseDead)
+                //.SetMaxSpellLevel()
                 .AddToDB();
+
+            ancientForestSpelllist.ClearSpellsByLevel();
+            ancientForestSpelllist.SpellsByLevel.AddRange(new List<SpellListDefinition.SpellsByLevelDuplet>()
+             {
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 0,
+                     Spells = new List<SpellDefinition>
+                     {
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 1,
+                     Spells = new List<SpellDefinition>
+                     {
+                         Goodberry,
+                         Entangle
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 2,
+                     Spells = new List<SpellDefinition>
+                     {
+                         Barkskin,
+                         SpikeGrowth
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 3,
+                     Spells = new List<SpellDefinition>
+                     {
+                         MassHealingWord,
+                         VampiricTouch
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 4,
+                     Spells = new List<SpellDefinition>
+                     {
+                         Contagion,
+                         RaiseDead
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 5,
+                     Spells = new List<SpellDefinition>
+                     {
+                         DominatePerson,
+                         FlameStrike
+                     }
+                 },
+
+             });
+
 
             //    necrotic and healing
 

--- a/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassMoonlit.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassMoonlit.cs
@@ -23,67 +23,67 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Subclasses
                 .Create(SpellListPaladin, "MoonLitExpandedSpelllist", DefinitionBuilder.CENamespaceGuid)
                 .SetGuiPresentation("MoonLitExpandedSpelllist", Category.Feature)
                 .SetGuiPresentationNoContent()
-                .ClearSpells()
-               // .SetSpellsAtLevel(1, FaerieFire, Sleep)
-               // .SetSpellsAtLevel(2, MoonBeam, SeeInvisibility)
-               // .SetSpellsAtLevel(3, Daylight, HypnoticPattern)
-               // .SetSpellsAtLevel(4, GreaterInvisibility, DominateBeast)
-               // .SetSpellsAtLevel(5, DominatePerson, FlameStrike)
-                .SetMaxSpellLevel(5, false)
+                //.ClearSpells()
+                //.SetSpellsAtLevel(1, FaerieFire, Sleep)
+                //.SetSpellsAtLevel(2, MoonBeam, SeeInvisibility)
+                //.SetSpellsAtLevel(3, Daylight, HypnoticPattern)
+                //.SetSpellsAtLevel(4, GreaterInvisibility, DominateBeast)
+                //.SetSpellsAtLevel(5, DominatePerson, FlameStrike)
+                //.SetMaxSpellLevel()
                 .AddToDB();
             MoonLitExpandedSpelllist.ClearSpellsByLevel();
             MoonLitExpandedSpelllist.SpellsByLevel.AddRange(new List<SpellListDefinition.SpellsByLevelDuplet>()
              {
-                // new SpellListDefinition.SpellsByLevelDuplet
-                // {
-                //     Level =0,
-                //     Spells = new List<SpellDefinition>
-                //     {
-                //     }
-                // },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =1,
+                     Level = 0,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.Sleep,
-                         DatabaseHelper.SpellDefinitions.FaerieFire
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =2,
+                     Level = 1,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.MoonBeam,
-                         DatabaseHelper.SpellDefinitions.SeeInvisibility
+                         Sleep,
+                         FaerieFire
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =3,
+                     Level = 2,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.Daylight,
-                         DatabaseHelper.SpellDefinitions.HypnoticPattern
+                         MoonBeam,
+                         SeeInvisibility
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =4,
+                     Level = 3,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.DominateBeast,
-                         DatabaseHelper.SpellDefinitions.GreaterInvisibility
+                         Daylight,
+                         HypnoticPattern
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =5,
+                     Level = 4,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.DominatePerson,
-                         DatabaseHelper.SpellDefinitions.FlameStrike
+                         DominateBeast,
+                         GreaterInvisibility
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 5,
+                     Spells = new List<SpellDefinition>
+                     {
+                         DominatePerson,
+                         FlameStrike
                      }
                  },
 

--- a/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassRiftWalker.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassRiftWalker.cs
@@ -170,76 +170,76 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Subclasses
         public static void RiftWalkerSpells()
         {
             SpellListDefinition RiftWalkerSpellList = SpellListDefinitionBuilder
-                   .Create(DatabaseHelper.SpellListDefinitions.SpellListPaladin, "RiftWalkerSpellsList", CENamespaceGuid)
-                   .SetGuiPresentation("RiftWalkerSpellsList", Category.SpellList)
-                   .ClearSpells()
-                 
-                //   .SetSpellsAtLevel(1, Jump, Longstrider)
-                //   .SetSpellsAtLevel(2, Blur, PassWithoutTrace)
-                //   .SetSpellsAtLevel(3, Haste, Slow)
-                //   .SetSpellsAtLevel(4, FreedomOfMovement, GreaterInvisibility)
-                //   .SetSpellsAtLevel(5, MindTwist, DispelEvilAndGood)
-                   .SetMaxSpellLevel(5, false)
-                   .AddToDB();
+                .Create(DatabaseHelper.SpellListDefinitions.SpellListPaladin, "RiftWalkerSpellsList", CENamespaceGuid)
+                .SetGuiPresentation("RiftWalkerSpellsList", Category.SpellList)
+                //.ClearSpells()
+                //.SetSpellsAtLevel(0) // Warlock class has Cantrips so if we don't add this the spell list gets screwed
+                //.SetSpellsAtLevel(1, Jump, Longstrider)
+                //.SetSpellsAtLevel(2, Blur, PassWithoutTrace)
+                //.SetSpellsAtLevel(3, Haste, Slow)
+                //.SetSpellsAtLevel(4, FreedomOfMovement, GreaterInvisibility)
+                //.SetSpellsAtLevel(5, MindTwist, DispelEvilAndGood)
+                //.SetMaxSpellLevel()
+                .AddToDB();
             RiftWalkerSpellList.ClearSpellsByLevel();
             RiftWalkerSpellList.SpellsByLevel.AddRange(new List<SpellListDefinition.SpellsByLevelDuplet>()
              {
-                // new SpellListDefinition.SpellsByLevelDuplet
-                // {
-                //     Level =0,
-                //     Spells = new List<SpellDefinition>
-                //     {
-                //     }
-                // },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =1,
+                     Level =0,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.Jump,
-                         DatabaseHelper.SpellDefinitions.Longstrider
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =2,
+                     Level = 1,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.Blur,
-                         DatabaseHelper.SpellDefinitions.PassWithoutTrace
+                         Jump,
+                         Longstrider
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =3,
+                     Level = 2,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.Haste,
-                         DatabaseHelper.SpellDefinitions.Slow
+                         Blur,
+                         PassWithoutTrace
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =4,
+                     Level = 3,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.FreedomOfMovement,
-                         DatabaseHelper.SpellDefinitions.GreaterInvisibility
+                         Haste,
+                         Slow
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =5,
+                     Level = 4,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.MindTwist,
-                         DatabaseHelper.SpellDefinitions.DispelEvilAndGood
+                         FreedomOfMovement,
+                         GreaterInvisibility
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 5,
+                     Spells = new List<SpellDefinition>
+                     {
+                         MindTwist,
+                         DispelEvilAndGood
                      }
                  },
 
              });
-         
-            
+
+
 
             RiftWalkerMagicAffinity = FeatureDefinitionMagicAffinityBuilder
                 .Create("RiftWalkerSpellsMagicAffinity", CENamespaceGuid)

--- a/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassToadKing.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Subclasses/DHWarlockSubclassToadKing.cs
@@ -9,6 +9,7 @@ using static SolastaModApi.DatabaseHelper.CharacterSubclassDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionDamageAffinitys;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionPowers;
 using static SolastaModApi.DatabaseHelper.ConditionDefinitions;
+using static SolastaModApi.DatabaseHelper.SpellDefinitions;
 using static SolastaModApi.DatabaseHelper.SpellListDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionProficiencys;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionMovementAffinitys;
@@ -24,67 +25,68 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Subclasses
                 .Create(SpellListPaladin, "ToadKingExpandedSpelllist", DefinitionBuilder.CENamespaceGuid)
                 .SetGuiPresentation("ToadKingExpandedSpelllist", Category.Feature)
                 .SetGuiPresentationNoContent()
-                .ClearSpells()
-               // .SetSpellsAtLevel(1, Grease, DetectPoisonAndDisease)
-               // .SetSpellsAtLevel(2, AcidArrow, SpiderClimb)
-               // .SetSpellsAtLevel(3, Slow, StinkingCloud)
-               // .SetSpellsAtLevel(4, BlackTentacles,FreedomOfMovement)
-               // .SetSpellsAtLevel(5, Contagion,InsectPlague)
-                .SetMaxSpellLevel(5, false)
+                //.ClearSpells()
+                //.SetSpellsAtLevel(0) // Warlock class has Cantrips so if we don't add this the spell list gets screwed
+                //.SetSpellsAtLevel(1, Longstrider, DetectPoisonAndDisease)
+                //.SetSpellsAtLevel(2, AcidArrow, SpiderClimb)
+                //.SetSpellsAtLevel(3, Slow, StinkingCloud)
+                //.SetSpellsAtLevel(4, BlackTentacles, FreedomOfMovement)
+                //.SetSpellsAtLevel(5, Contagion, InsectPlague)
+                //.SetMaxSpellLevel()
                 .AddToDB();
             ToadKingExpandedSpelllist.ClearSpellsByLevel();
             ToadKingExpandedSpelllist.SpellsByLevel.AddRange(new List<SpellListDefinition.SpellsByLevelDuplet>()
              {
-               //  new SpellListDefinition.SpellsByLevelDuplet
-               //  {
-               //      Level =0,
-               //      Spells = new List<SpellDefinition>
-               //      {
-               //      }
-               //  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =1,
+                     Level = 0,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.DetectPoisonAndDisease,
-                         DatabaseHelper.SpellDefinitions.Longstrider
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =2,
+                     Level = 1,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.AcidArrow,
-                         DatabaseHelper.SpellDefinitions.SpiderClimb
+                         DetectPoisonAndDisease,
+                         Longstrider
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =3,
+                     Level = 2,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.StinkingCloud,
-                         DatabaseHelper.SpellDefinitions.Slow
+                         AcidArrow,
+                         SpiderClimb
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =4,
+                     Level = 3,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.FreedomOfMovement,
-                         DatabaseHelper.SpellDefinitions.BlackTentacles
+                         StinkingCloud,
+                         Slow
                      }
                  },
                  new SpellListDefinition.SpellsByLevelDuplet
                  {
-                     Level =5,
+                     Level = 4,
                      Spells = new List<SpellDefinition>
                      {
-                         DatabaseHelper.SpellDefinitions.Contagion,
-                         DatabaseHelper.SpellDefinitions.InsectPlague
+                         FreedomOfMovement,
+                         BlackTentacles
+                     }
+                 },
+                 new SpellListDefinition.SpellsByLevelDuplet
+                 {
+                     Level = 5,
+                     Spells = new List<SpellDefinition>
+                     {
+                         Contagion,
+                         InsectPlague
                      }
                  },
 
@@ -163,7 +165,7 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Subclasses
                                 0,
                                 RuleDefinitions.AdvancementDuration.None
                                 )
-                            .SetParticleEffectParameters(DatabaseHelper.SpellDefinitions.Thunderwave.EffectDescription.EffectParticleParameters)
+                            .SetParticleEffectParameters(Thunderwave.EffectDescription.EffectParticleParameters)
                             .Build()
                        ,
                        true)


### PR DESCRIPTION
@PhilPJL : for some reason the SetAtSpellLevel is screwing up the spell offering (i.e.: getting sleep as cantrip). Rolled back the changes and ensured all 4 subs are working. I reviewed all other classes and only Warlock and Witch main spell list use SetAtSpellLevel. They work fine as they have a non empty cantrip list.