### PR TITLE
fix feature custom code removal logic

### DIFF
--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/CharacterBuildingManagerPatcher.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using HarmonyLib;
+using SolastaCommunityExpansion.CustomDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures.RecursiveGrantCustomFeatures
 {
@@ -15,6 +17,40 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.RecursiveGrantCustomF
         internal static void Prefix(RulesetCharacterHero hero, List<FeatureDefinition> grantedFeatures)
         {
             Models.CustomFeaturesContext.RecursiveGrantCustomFeatures(hero, grantedFeatures);
+        }
+    }
+
+    // undo any custom logic when removing features
+    [HarmonyPatch(typeof(CharacterBuildingManager), "UnassignLastClassLevel")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharacterBuildingManager_UnassignLastClassLevel
+    {
+        internal static void Prefix(RulesetCharacterHero hero)
+        {
+            var heroBuildingData = hero.GetHeroBuildingData();
+            
+            foreach (var feature in heroBuildingData.AllActiveFeatures
+                .OfType<FeatureDefinitionCustomCode>())
+            {
+                feature.RemoveFeature(hero);
+            }
+        }
+    }
+
+    // undo any custom logic when removing features
+    [HarmonyPatch(typeof(CharacterBuildingManager), "UnassignLastSubclass")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharacterBuildingManager_UnassignLastSubclass
+    {
+        internal static void Prefix(RulesetCharacterHero hero)
+        {
+            var heroBuildingData = hero.GetHeroBuildingData();
+
+            foreach (var feature in heroBuildingData.AllActiveFeatures
+                .OfType<FeatureDefinitionCustomCode>())
+            {
+                feature.RemoveFeature(hero);
+            }
         }
     }
 }


### PR DESCRIPTION
- Add 2 new patches to correctly enforce removal logic on FeatureDefinitionCustomCode