### PR TITLE
fix ancestry cantrips display off battle

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUi/CharacterPanel/SpellSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharacterPanel/SpellSelectionPanelPatcher.cs
@@ -167,6 +167,12 @@ namespace SolastaCommunityExpansion.Patches.GameUi.CharacterPanel
 
                 if (level == 0)
                 {
+                    // changed to support game v1.3.44 and allow ancestry cantrips to display off battle
+                    if (actionType == ActionDefinitions.ActionType.None)
+                    {
+                        return true;
+                    }
+
                     foreach (SpellDefinition cantrip in spellRepertoire.KnownCantrips)
                     {
                         if (cantrip.ActivationTime == spellActivationTime)


### PR DESCRIPTION
- very special case when a race has ancestry cantrips and is also a caster. ActionType is none off battle and it was getting ripped from display
- taking a conservative approach here with the IF there instead of another case in the above switch