### PR TITLE
Flexible backgrounds fixes

### DIFF
--- a/SolastaCommunityExpansion/Models/FlexibleBackgroundsContext.cs
+++ b/SolastaCommunityExpansion/Models/FlexibleBackgroundsContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Builders.Features;
 using static SolastaModApi.DatabaseHelper.CharacterBackgroundDefinitions;
@@ -8,6 +9,10 @@ namespace SolastaCommunityExpansion.Models
 {
     public static class FlexibleBackgroundsContext
     {
+        private const string FlexibleBackgroundsGuid = "f7713746-2028-410d-9df6-20f261f4d6aa";
+
+        public static readonly Guid FLEX_BACK_BASE_GUID = new(FlexibleBackgroundsGuid);
+
         private static readonly FeatureDefinition skillThree = FeatureDefinitionPointPoolBuilder
             .Create("BackgroundSkillSelect3", "e6f2ed65-a44e-4314-b38c-393abb4ad900")
             .SetGuiPresentation(Category.FlexibleBackgrounds)
@@ -26,17 +31,68 @@ namespace SolastaCommunityExpansion.Models
             .SetPool(HeroDefinitions.PointsPoolType.Tool, 1)
             .AddToDB();
 
+        private static readonly FeatureDefinition toolTwo = FeatureDefinitionPointPoolBuilder
+            .Create("BackgroundToolSelect2", "07d30e58-eddc-43eb-a24c-71f107b8d76a")
+            .SetGuiPresentation(Category.FlexibleBackgrounds)
+            .SetPool(HeroDefinitions.PointsPoolType.Tool, 2)
+            .AddToDB();
+
+        private static FeatureDefinition academicSuggestedSkills = FeatureDefinitionBuilder
+    .Create("AcademicBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+    .SetGuiPresentation("AcademicBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+    .AddToDB();
+
+        private static FeatureDefinition acolyteSuggestedSkills = FeatureDefinitionBuilder
+           .Create("AcolyteBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("AcolyteBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition aristocratSuggestedSkills = FeatureDefinitionBuilder
+            .Create("AristocratBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("AristocratBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition lawkeeperSuggestedSkills = FeatureDefinitionBuilder
+            .Create("LawkeeperBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("LawkeeperBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition lowlifeSuggestedSkills = FeatureDefinitionBuilder
+            .Create("LowlifeBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("LowlifeBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition philosopherSuggestedSkills = FeatureDefinitionBuilder
+            .Create("PhilosopherBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("PhilosopherBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition sellswordSuggestedSkills = FeatureDefinitionBuilder
+            .Create("SellswordBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("SellswordBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition spySuggestedSkills = FeatureDefinitionBuilder
+            .Create("SpyBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("SpyBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
+        private static FeatureDefinition wandererSuggestedSkills = FeatureDefinitionBuilder
+            .Create("WandererBackgroundSuggestedSkills", FLEX_BACK_BASE_GUID)
+            .SetGuiPresentation("WandererBackgroundSuggestedSkills", Category.FlexibleBackgrounds)
+            .AddToDB();
+
         private static readonly Dictionary<CharacterBackgroundDefinition, List<FeatureDefinition>> addedFeatures = new()
         {
-            { Academic, new List<FeatureDefinition> { skillThree, toolChoice } },
-            { Acolyte, new List<FeatureDefinition> { skillThree, toolChoice } },
-            { Aristocrat, new List<FeatureDefinition> { skillThree } },
-            { Lawkeeper, new List<FeatureDefinition> { skillThree } },
-            { Lowlife, new List<FeatureDefinition> { skillTwo, toolChoice } },
-            { Philosopher, new List<FeatureDefinition> { skillThree, toolChoice } },
-            { SellSword, new List<FeatureDefinition> { skillTwo, toolChoice } },
-            { Spy, new List<FeatureDefinition> { skillTwo, toolChoice } },
-            { Wanderer, new List<FeatureDefinition> { skillThree, toolChoice } },
+            { Academic, new List<FeatureDefinition> { skillThree, academicSuggestedSkills, toolChoice } },
+            { Acolyte, new List<FeatureDefinition> { skillThree, acolyteSuggestedSkills, toolChoice } },
+            { Aristocrat, new List<FeatureDefinition> { skillThree, aristocratSuggestedSkills } },
+            { Lawkeeper, new List<FeatureDefinition> { skillTwo, lawkeeperSuggestedSkills } },
+            { Lowlife, new List<FeatureDefinition> { skillThree, lowlifeSuggestedSkills, toolChoice } },
+            { Philosopher, new List<FeatureDefinition> { skillTwo, philosopherSuggestedSkills, toolChoice } },
+            { SellSword, new List<FeatureDefinition> { skillTwo, sellswordSuggestedSkills, toolChoice } },
+            { Spy, new List<FeatureDefinition> { skillThree, spySuggestedSkills, toolChoice } },
+            { Wanderer, new List<FeatureDefinition> { skillTwo, wandererSuggestedSkills, toolTwo } },
         };
 
         private static readonly Dictionary<CharacterBackgroundDefinition, List<FeatureDefinition>> removedFeatures = new()

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -1057,12 +1057,32 @@ FightingStyle/&BlindFightingDescription	You have blindsight with a range of 10 f
 FightingStyle/&BlindFightingTitle	Blind Fighting
 FightingStyle/&PugilistFightingDescription	While you are completely unarmed, your unarmed strikes deal an additional d8 of damage and you can punch with your offhand as a bonus action.
 FightingStyle/&PugilistFightingTitle	Pugilist
+FlexibleBackgrounds/&AcademicBackgroundSuggestedSkillsDescription	Arcana, Nature, and Insight
+FlexibleBackgrounds/&AcademicBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&AcolyteBackgroundSuggestedSkillsDescription	Religion, Nature, and Insight
+FlexibleBackgrounds/&AcolyteBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&AristocratBackgroundSuggestedSkillsDescription	History, Persuasion, and Intimidation
+FlexibleBackgrounds/&AristocratBackgroundSuggestedSkillsTitle	Suggested Skills
 FlexibleBackgrounds/&BackgroundSkillSelect2Description	Select 2 skill proficiencies
 FlexibleBackgrounds/&BackgroundSkillSelect2Title	Skills
 FlexibleBackgrounds/&BackgroundSkillSelect3Description	Select 3 skill proficiencies
 FlexibleBackgrounds/&BackgroundSkillSelect3Title	Skills
 FlexibleBackgrounds/&BackgroundToolSelectDescription	Select a tool proficiency
 FlexibleBackgrounds/&BackgroundToolSelectTitle	Tool
+FlexibleBackgrounds/&BackgroundToolSelect2Description	Select 2 tool proficiencies
+FlexibleBackgrounds/&BackgroundToolSelect2Title	Tools
+FlexibleBackgrounds/&LawkeeperBackgroundSuggestedSkillsDescription	Perception and Intimidation
+FlexibleBackgrounds/&LawkeeperBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&LowlifeBackgroundSuggestedSkillsDescription	Sleight of Hand, Stealth, and Deception
+FlexibleBackgrounds/&LowlifeBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&PhilosopherBackgroundSuggestedSkillsDescription	Medicine and Persuasion
+FlexibleBackgrounds/&PhilosopherBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&SellswordBackgroundSuggestedSkillsDescription	Athletics and Intimidation
+FlexibleBackgrounds/&SellswordBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&SpyBackgroundSuggestedSkillsDescription	Stealth, Deception, and Nature
+FlexibleBackgrounds/&SpyBackgroundSuggestedSkillsTitle	Suggested Skills
+FlexibleBackgrounds/&WandererBackgroundSuggestedSkillsDescription	Survival and Nature
+FlexibleBackgrounds/&WandererBackgroundSuggestedSkillsTitle	Suggested Skills
 FlexibleRaces/&PointPoolAbilityScore3Description	Use three boosts on ability scores in any combination of your choosing.
 FlexibleRaces/&PointPoolAbilityScore3Title	Ability Score Increase
 FlexibleRaces/&PointPoolAbilityScore4Description	Use four boosts on ability scores in any combination of your choosing.


### PR DESCRIPTION
I noticed that some of the Flexible Backgrounds did not correctly match the number of skills and/or tools actually granted by the background in the base game. These changes fix that. I also added blank features to display the original defaults as "Suggested Skills". This preserves the intended flavor of the background as written and also is helpful for those of us who mainly just use it to duplicate the D&D rule that you can choose a different skill or tool if your background grants one you already have from another source
![FlexibleBackgroundsFixWanderer](https://user-images.githubusercontent.com/86208060/163747181-2a1d0828-f1f9-45d8-b9ec-d7f215b6bcd5.PNG)
.