### PR TITLE
Remove feature UseHeightOneCylinderEffect

### DIFF
--- a/SolastaCommunityExpansion/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Displays/RulesDisplay.cs
@@ -134,13 +134,13 @@ namespace SolastaCommunityExpansion.Displays
                 Main.Settings.QuickCastLightCantripOnWornItemsFirst = toggle;
             }
 
-            toggle = Main.Settings.UseHeightOneCylinderEffect;
-            if (UI.Toggle("Display a height 1 cylinder effect when casting " + "Black Tentacles, Entangle, Grease ".orange() +
-                " (square cylinder), ".yellow() + "Spike Growth".orange() + " (round cylinder).".yellow(), ref toggle, UI.AutoWidth()))
-            {
-                Main.Settings.UseHeightOneCylinderEffect = toggle;
-                HouseSpellTweaks.UseHeightOneCylinderEffect();
-            }
+            //toggle = Main.Settings.UseHeightOneCylinderEffect;
+            //if (UI.Toggle("Display a height 1 cylinder effect when casting " + "Black Tentacles, Entangle, Grease ".orange() +
+            //    " (square cylinder), ".yellow() + "Spike Growth".orange() + " (round cylinder).".yellow(), ref toggle, UI.AutoWidth()))
+            //{
+            //    Main.Settings.UseHeightOneCylinderEffect = toggle;
+            //    HouseSpellTweaks.UseHeightOneCylinderEffect();
+            //}
 
             UI.Label("");
 

--- a/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SquareCylinder/GeometryPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/SrdAndHouseRules/SquareCylinder/GeometryPatcher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if false
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using HarmonyLib;
@@ -253,3 +254,4 @@ namespace SolastaCommunityExpansion.Patches.SrdAndHouseRules.SquareCylinder
     }
 #endif
 }
+#endif

--- a/SolastaCommunityExpansion/Settings.cs
+++ b/SolastaCommunityExpansion/Settings.cs
@@ -170,7 +170,7 @@ namespace SolastaCommunityExpansion
         public bool MakeAllMagicStaveArcaneFoci { get; set; }
         public bool IncreaseSenseNormalVision { get; set; }
         public bool QuickCastLightCantripOnWornItemsFirst { get; set; }
-        public bool UseHeightOneCylinderEffect { get; set; }
+        //public bool UseHeightOneCylinderEffect { get; set; }
         public bool AddPickpocketableLoot { get; set; }
         public bool AllowStackedMaterialComponent { get; set; }
         public bool ScaleMerchantPricesCorrectly { get; set; }

--- a/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
+++ b/SolastaCommunityExpansion/Spells/HouseSpellTweaks.cs
@@ -11,7 +11,7 @@ namespace SolastaCommunityExpansion.Spells
         public static void Register()
         {
             AddBleedingToRestoration();
-            UseHeightOneCylinderEffect();
+            //UseHeightOneCylinderEffect();
             MinorFixes();
         }
 
@@ -42,6 +42,7 @@ namespace SolastaCommunityExpansion.Spells
             }
         }
 
+#if false
         internal static void UseHeightOneCylinderEffect()
         {
             // always applicable
@@ -110,6 +111,7 @@ namespace SolastaCommunityExpansion.Spells
                 }
             }
         }
+#endif
 
         public static void AddBleedingToRestoration()
         {


### PR DESCRIPTION
- There was more than one report stating that some spells are getting weird ranges or not working at all when this setting is enabled. This was written by @PhilPJL and I don't understand this code pretty well to maintain it. Temporarily disabling the feature...

Spells reported so far:

1. Flaming Sphere (mentioned on this feature code comment)

![image](https://user-images.githubusercontent.com/13087646/163929638-5cbbc5ab-dce2-4a85-a4a1-cb3370d99e7c.png)

3. Thunderwave (also affected by cube forms this feature touches)

![image](https://user-images.githubusercontent.com/13087646/163930432-08719fcf-d128-47fe-bfd8-27fd4cf59d3d.png)

