### PR TITLE
Custom race character scaling

### DIFF
--- a/SolastaCommunityExpansion/Patches/CustomFeatures/Races/GraphicsCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/Races/GraphicsCharacterPatcher.cs
@@ -1,41 +1,31 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
-using static SolastaModApi.DatabaseHelper.CharacterRaceDefinitions;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures.Races
 {
         [HarmonyPatch(typeof(GraphicsCharacter), "ResetScale")]
         class GraphicsCharacter_ResetScale
         {
-		    //Both scales work, just have to make them work together now
-            //const float bolgrifScaleMap = 7.8f /6.4f;
-
-            const float gnomeScaleMap = -0.02f /-0.03f;
-        
-			
             internal static void Postfix(GraphicsCharacter __instance, ref float __result)
             {
+                Dictionary<CharacterRaceDefinition, float> raceScaleMap = new Dictionary<CharacterRaceDefinition, float>();
+                
+                raceScaleMap[SolastaCommunityExpansion.Races.BolgrifRaceBuilder.BolgrifRace] = 8.8f / 6.4f;
+                raceScaleMap[SolastaCommunityExpansion.Races.GnomeRaceBuilder.GnomeRace] = -0.04f / -0.06f;
+                
                 var race = (__instance.RulesetCharacter as RulesetCharacterHero)?.RaceDefinition;
-				
-				if (/*race != SolastaCommunityExpansion.Races.BolgrifRaceBuilder.BolgrifRace &&*/ race != SolastaCommunityExpansion.Races.GnomeRaceBuilder.GnomeRace)
-				{
-					return;
-				}
+                
+                if (race != null && raceScaleMap.ContainsKey(race))
+                {
+                    __result *= raceScaleMap[race];
+                }
+                else
+                {
+                    __result *= 1.0f / 1.0f;
+                }
 
-                    //__result *= bolgrifScaleMap;
-                    //__instance.transform.localScale = new Vector3(__result, __result, __result);
-
-
-                    __result *= gnomeScaleMap;
-                    __instance.transform.localScale = new Vector3(__result, __result, __result);
-
-
+                __instance.transform.localScale = new Vector3(__result, __result, __result);
 
             }
         }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/Races/GraphicsCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/Races/GraphicsCharacterPatcher.cs
@@ -1,0 +1,42 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using static SolastaModApi.DatabaseHelper.CharacterRaceDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.CustomFeatures.Races
+{
+        [HarmonyPatch(typeof(GraphicsCharacter), "ResetScale")]
+        class GraphicsCharacter_ResetScale
+        {
+		    //Both scales work, just have to make them work together now
+            //const float bolgrifScaleMap = 7.8f /6.4f;
+
+            const float gnomeScaleMap = -0.02f /-0.03f;
+        
+			
+            internal static void Postfix(GraphicsCharacter __instance, ref float __result)
+            {
+                var race = (__instance.RulesetCharacter as RulesetCharacterHero)?.RaceDefinition;
+				
+				if (/*race != SolastaCommunityExpansion.Races.BolgrifRaceBuilder.BolgrifRace &&*/ race != SolastaCommunityExpansion.Races.GnomeRaceBuilder.GnomeRace)
+				{
+					return;
+				}
+
+                    //__result *= bolgrifScaleMap;
+                    //__instance.transform.localScale = new Vector3(__result, __result, __result);
+
+
+                    __result *= gnomeScaleMap;
+                    __instance.transform.localScale = new Vector3(__result, __result, __result);
+
+
+
+            }
+        }
+}

--- a/SolastaCommunityExpansion/Races/Bolgrif.cs
+++ b/SolastaCommunityExpansion/Races/Bolgrif.cs
@@ -74,17 +74,17 @@ namespace SolastaCommunityExpansion.Races
                 .SetProficiencies(RuleDefinitions.ProficiencyType.Language, "Language_Common", "Language_Giant", "Language_Elvish")
                 .AddToDB();
 
-            var bolgrifRacePresentation = CharacterRaceDefinitions.Elf.RacePresentation.DeepCopy();
+            var bolgrifRacePresentation = CharacterRaceDefinitions.Dwarf.RacePresentation.DeepCopy();
 
-            bolgrifRacePresentation.SetBodyAssetPrefix(CharacterRaceDefinitions.Elf.RacePresentation.BodyAssetPrefix);
-            bolgrifRacePresentation.SetMorphotypeAssetPrefix(CharacterRaceDefinitions.Elf.RacePresentation.MorphotypeAssetPrefix);
+            bolgrifRacePresentation.SetBodyAssetPrefix(CharacterRaceDefinitions.Dwarf.RacePresentation.BodyAssetPrefix);
+            bolgrifRacePresentation.SetMorphotypeAssetPrefix(CharacterRaceDefinitions.Dwarf.RacePresentation.MorphotypeAssetPrefix);
             bolgrifRacePresentation.SetPreferedSkinColors(new TA.RangedInt(45, 48));
             bolgrifRacePresentation.SetPreferedHairColors(new TA.RangedInt(16, 32));
             bolgrifRacePresentation.SetMaleBeardShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.MaleBeardShapeOptions);
             bolgrifRacePresentation.FemaleFaceShapeOptions.Clear();
             bolgrifRacePresentation.MaleFaceShapeOptions.Clear();
-            bolgrifRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.Elf.RacePresentation.FemaleFaceShapeOptions);
-            bolgrifRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.Elf.RacePresentation.MaleFaceShapeOptions);
+            bolgrifRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.FemaleFaceShapeOptions);
+            bolgrifRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.MaleFaceShapeOptions);
 
             var bolgrif = CharacterRaceDefinitionBuilder
                 .Create(CharacterRaceDefinitions.Human, "BolgrifRace", "346b7f90-973f-425f-8342-d534759e65aa")

--- a/SolastaCommunityExpansion/Races/Bolgrif.cs
+++ b/SolastaCommunityExpansion/Races/Bolgrif.cs
@@ -93,8 +93,8 @@ namespace SolastaCommunityExpansion.Races
                 .SetRacePresentation(bolgrifRacePresentation)
                 .SetMinimalAge(30)
                 .SetMaximalAge(500)
-                .SetBaseHeight(96)
-                .SetBaseWeight(130)
+                .SetBaseHeight(84)
+                .SetBaseWeight(170)
                 .SetFeaturesAtLevel(1,
                     FeatureDefinitionMoveModes.MoveModeMove6,
                     bolgrifAbilityScoreModifierWisdom,

--- a/SolastaCommunityExpansion/Races/Bolgrif.cs
+++ b/SolastaCommunityExpansion/Races/Bolgrif.cs
@@ -85,7 +85,7 @@ namespace SolastaCommunityExpansion.Races
             bolgrifRacePresentation.MaleFaceShapeOptions.Clear();
             bolgrifRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.FemaleFaceShapeOptions);
             bolgrifRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.MaleFaceShapeOptions);
-
+            
             var bolgrif = CharacterRaceDefinitionBuilder
                 .Create(CharacterRaceDefinitions.Human, "BolgrifRace", "346b7f90-973f-425f-8342-d534759e65aa")
                 .SetGuiPresentation(Category.Race, bolgrifSpriteReference)

--- a/SolastaCommunityExpansion/Races/Bolgrif.cs
+++ b/SolastaCommunityExpansion/Races/Bolgrif.cs
@@ -76,15 +76,8 @@ namespace SolastaCommunityExpansion.Races
 
             var bolgrifRacePresentation = CharacterRaceDefinitions.Dwarf.RacePresentation.DeepCopy();
 
-            bolgrifRacePresentation.SetBodyAssetPrefix(CharacterRaceDefinitions.Dwarf.RacePresentation.BodyAssetPrefix);
-            bolgrifRacePresentation.SetMorphotypeAssetPrefix(CharacterRaceDefinitions.Dwarf.RacePresentation.MorphotypeAssetPrefix);
             bolgrifRacePresentation.SetPreferedSkinColors(new TA.RangedInt(45, 48));
             bolgrifRacePresentation.SetPreferedHairColors(new TA.RangedInt(16, 32));
-            bolgrifRacePresentation.SetMaleBeardShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.MaleBeardShapeOptions);
-            bolgrifRacePresentation.FemaleFaceShapeOptions.Clear();
-            bolgrifRacePresentation.MaleFaceShapeOptions.Clear();
-            bolgrifRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.FemaleFaceShapeOptions);
-            bolgrifRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.Dwarf.RacePresentation.MaleFaceShapeOptions);
             
             var bolgrif = CharacterRaceDefinitionBuilder
                 .Create(CharacterRaceDefinitions.Human, "BolgrifRace", "346b7f90-973f-425f-8342-d534759e65aa")

--- a/SolastaCommunityExpansion/Races/Gnome.cs
+++ b/SolastaCommunityExpansion/Races/Gnome.cs
@@ -62,15 +62,15 @@ namespace SolastaCommunityExpansion.Races
                 .SetProficiencies(RuleDefinitions.ProficiencyType.Language, "Language_Common", languageGnomish.Name)
                 .AddToDB();
 
-            var gnomeRacePresentation = CharacterRaceDefinitions.Halfling.RacePresentation.DeepCopy();
+            var gnomeRacePresentation = CharacterRaceDefinitions.HalfElf.RacePresentation.DeepCopy();
 
-            gnomeRacePresentation.SetBodyAssetPrefix(CharacterRaceDefinitions.Elf.RacePresentation.BodyAssetPrefix);
-            gnomeRacePresentation.SetMorphotypeAssetPrefix(CharacterRaceDefinitions.Elf.RacePresentation.MorphotypeAssetPrefix);
+            gnomeRacePresentation.SetBodyAssetPrefix(CharacterRaceDefinitions.HalfElf.RacePresentation.BodyAssetPrefix);
+            gnomeRacePresentation.SetMorphotypeAssetPrefix(CharacterRaceDefinitions.HalfElf.RacePresentation.MorphotypeAssetPrefix);
             gnomeRacePresentation.SetPreferedHairColors(new TA.RangedInt(26, 47));
             gnomeRacePresentation.FemaleFaceShapeOptions.Clear();
             gnomeRacePresentation.MaleFaceShapeOptions.Clear();
-            gnomeRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.Elf.RacePresentation.FemaleFaceShapeOptions);
-            gnomeRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.Elf.RacePresentation.MaleFaceShapeOptions);
+            gnomeRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.HalfElf.RacePresentation.FemaleFaceShapeOptions);
+            gnomeRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.HalfElf.RacePresentation.MaleFaceShapeOptions);
 
             var gnome = CharacterRaceDefinitionBuilder
                 .Create(CharacterRaceDefinitions.Human, "GnomeRace", "ce63140e-c018-4f83-8e6e-bc7bbc815a17")

--- a/SolastaCommunityExpansion/Races/Gnome.cs
+++ b/SolastaCommunityExpansion/Races/Gnome.cs
@@ -64,13 +64,7 @@ namespace SolastaCommunityExpansion.Races
 
             var gnomeRacePresentation = CharacterRaceDefinitions.HalfElf.RacePresentation.DeepCopy();
 
-            gnomeRacePresentation.SetBodyAssetPrefix(CharacterRaceDefinitions.HalfElf.RacePresentation.BodyAssetPrefix);
-            gnomeRacePresentation.SetMorphotypeAssetPrefix(CharacterRaceDefinitions.HalfElf.RacePresentation.MorphotypeAssetPrefix);
             gnomeRacePresentation.SetPreferedHairColors(new TA.RangedInt(26, 47));
-            gnomeRacePresentation.FemaleFaceShapeOptions.Clear();
-            gnomeRacePresentation.MaleFaceShapeOptions.Clear();
-            gnomeRacePresentation.AddFemaleFaceShapeOptions(CharacterRaceDefinitions.HalfElf.RacePresentation.FemaleFaceShapeOptions);
-            gnomeRacePresentation.AddMaleFaceShapeOptions(CharacterRaceDefinitions.HalfElf.RacePresentation.MaleFaceShapeOptions);
 
             var gnome = CharacterRaceDefinitionBuilder
                 .Create(CharacterRaceDefinitions.Human, "GnomeRace", "ce63140e-c018-4f83-8e6e-bc7bbc815a17")


### PR DESCRIPTION
Scaling now works. Due to beard issues, I went with all Dwarf models for Bolgrif. I also changed Gnome to a scaled down HalfElf for the slightly pointed ears. The GraphicsCharacterFactoryManagerPatcher is not needed if you accept the change to Dwarf morphotypes. Attached Image: Gnome, Bolgrif, Human, Halfling
![GnomeBolgrifHumanHalfling](https://user-images.githubusercontent.com/86208060/164042933-364a646d-83f2-4bc1-a82f-94f262881347.PNG)

