### PR TITLE
Spells display fix

### DIFF
--- a/SolastaCommunityExpansion/Models/SpellsContext.cs
+++ b/SolastaCommunityExpansion/Models/SpellsContext.cs
@@ -14,14 +14,12 @@ namespace SolastaCommunityExpansion.Models
             private List<string> SelectedSpells => Main.Settings.SpellListSpellEnabled[SpellList.Name];
             public SpellListDefinition SpellList { get; private set; }
             public HashSet<SpellDefinition> AllSpells { get; private set; }
-            //public HashSet<SpellDefinition> MinimumSpells { get; private set; }
             public HashSet<SpellDefinition> SuggestedSpells { get; private set; }
 
             public SpellListContext(SpellListDefinition spellListDefinition)
             {
                 SpellList = spellListDefinition;
                 AllSpells = new();
-                //MinimumSpells = new();
                 SuggestedSpells = new();
             }
 
@@ -225,7 +223,6 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void RegisterSpell(
             SpellDefinition spellDefinition,
-            //int suggestedStartsAt = 0,
             params SpellListDefinition[] spellLists)
         {
             if (Spells.Contains(spellDefinition))
@@ -239,17 +236,10 @@ namespace SolastaCommunityExpansion.Models
             {
                 var spellList = spellLists[i];
 
-                /*if (i < suggestedStartsAt)
-                {
-                    SpellListContextTab[spellList].MinimumSpells.Add(spellDefinition);
-                }
-                else
-                {*/
-                    var enable = Main.Settings.SpellListSpellEnabled[spellList.Name].Contains(spellDefinition.Name);
+                var enable = Main.Settings.SpellListSpellEnabled[spellList.Name].Contains(spellDefinition.Name);
 
-                    SpellListContextTab[spellList].Switch(spellDefinition, enable);
-                    SpellListContextTab[spellList].SuggestedSpells.Add(spellDefinition);
-                //}
+                SpellListContextTab[spellList].Switch(spellDefinition, enable);
+                SpellListContextTab[spellList].SuggestedSpells.Add(spellDefinition);
             }
         }
 

--- a/SolastaCommunityExpansion/Models/SpellsContext.cs
+++ b/SolastaCommunityExpansion/Models/SpellsContext.cs
@@ -14,14 +14,14 @@ namespace SolastaCommunityExpansion.Models
             private List<string> SelectedSpells => Main.Settings.SpellListSpellEnabled[SpellList.Name];
             public SpellListDefinition SpellList { get; private set; }
             public HashSet<SpellDefinition> AllSpells { get; private set; }
-            public HashSet<SpellDefinition> MinimumSpells { get; private set; }
+            //public HashSet<SpellDefinition> MinimumSpells { get; private set; }
             public HashSet<SpellDefinition> SuggestedSpells { get; private set; }
 
             public SpellListContext(SpellListDefinition spellListDefinition)
             {
                 SpellList = spellListDefinition;
                 AllSpells = new();
-                MinimumSpells = new();
+                //MinimumSpells = new();
                 SuggestedSpells = new();
             }
 
@@ -38,7 +38,7 @@ namespace SolastaCommunityExpansion.Models
                 AllSpells.Clear();
 
                 foreach (var spell in Spells
-                    .Where(x => x.SpellLevel >= minSpellLevel && x.SpellLevel <= maxSpellLevel && !MinimumSpells.Contains(x)))
+                    .Where(x => x.SpellLevel >= minSpellLevel && x.SpellLevel <= maxSpellLevel /*&& !MinimumSpells.Contains(x)*/))
                 {
                     AllSpells.Add(spell);
                 }
@@ -225,7 +225,7 @@ namespace SolastaCommunityExpansion.Models
 
         internal static void RegisterSpell(
             SpellDefinition spellDefinition,
-            int suggestedStartsAt = 0,
+            //int suggestedStartsAt = 0,
             params SpellListDefinition[] spellLists)
         {
             if (Spells.Contains(spellDefinition))
@@ -239,17 +239,17 @@ namespace SolastaCommunityExpansion.Models
             {
                 var spellList = spellLists[i];
 
-                if (i < suggestedStartsAt)
+                /*if (i < suggestedStartsAt)
                 {
                     SpellListContextTab[spellList].MinimumSpells.Add(spellDefinition);
                 }
                 else
-                {
+                {*/
                     var enable = Main.Settings.SpellListSpellEnabled[spellList.Name].Contains(spellDefinition.Name);
 
                     SpellListContextTab[spellList].Switch(spellDefinition, enable);
                     SpellListContextTab[spellList].SuggestedSpells.Add(spellDefinition);
-                }
+                //}
             }
         }
 

--- a/SolastaCommunityExpansion/Spells/AceHighSpells.cs
+++ b/SolastaCommunityExpansion/Spells/AceHighSpells.cs
@@ -15,7 +15,7 @@ namespace SolastaCommunityExpansion.Spells
 
         internal static void Register()
         {
-            RegisterSpell(PactMarkSpell, 1, WarlockSpellList);
+            RegisterSpell(PactMarkSpell, WarlockSpellList);
         }
 
         internal class PactMarkSpellBuilder : SpellDefinitionBuilder

--- a/SolastaCommunityExpansion/Spells/BazouSpells.cs
+++ b/SolastaCommunityExpansion/Spells/BazouSpells.cs
@@ -51,12 +51,12 @@ namespace SolastaCommunityExpansion.Spells
 */
         internal static void Register()
         {
-            RegisterSpell(EldritchOrb, 1, WitchSpellList, WarlockSpellList);
-            RegisterSpell(FindFamiliar, 1, WitchSpellList, SpellListWizard);
-            RegisterSpell(Frenzy, 1, WitchSpellList, WarlockSpellList, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(MinorLifesteal, 1, WitchSpellList, SpellListWizard);
-            RegisterSpell(PetalStorm, 1, WitchSpellList, SpellListDruid);
-            RegisterSpell(ProtectThreshold, 1, WitchSpellList, SpellListCleric, SpellListDruid, SpellListPaladin);
+            RegisterSpell(EldritchOrb, WitchSpellList, WarlockSpellList);
+            RegisterSpell(FindFamiliar, WitchSpellList, SpellListWizard);
+            RegisterSpell(Frenzy, WitchSpellList, WarlockSpellList, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(MinorLifesteal, WitchSpellList, SpellListWizard);
+            RegisterSpell(PetalStorm, WitchSpellList, SpellListDruid);
+            RegisterSpell(ProtectThreshold, WitchSpellList, SpellListCleric, SpellListDruid, SpellListPaladin);
         }
 
         private static SpellDefinition BuildEldritchOrb()

--- a/SolastaCommunityExpansion/Spells/HolicSpells.cs
+++ b/SolastaCommunityExpansion/Spells/HolicSpells.cs
@@ -35,12 +35,12 @@ namespace SolastaCommunityExpansion.Spells
 
         internal static void Register()
         {
-            RegisterSpell(AcidClaw, 0, SpellListDruid);
-            RegisterSpell(AirBlast, 0, SpellListWizard, SpellListSorcerer, SpellListDruid);
-            RegisterSpell(BurstOfRadiance, 0, SpellListCleric);
-            RegisterSpell(ThunderStrike, 0, SpellListWizard, SpellListSorcerer, SpellListDruid);
-            RegisterSpell(EarthTremor, 0, SpellListWizardGreenmage, SpellListWizard, SpellListSorcerer, SpellListDruid);
-            RegisterSpell(WinterBreath, 0, SpellListWizardGreenmage, SpellListDruid);
+            RegisterSpell(AcidClaw, SpellListDruid);
+            RegisterSpell(AirBlast, SpellListWizard, SpellListSorcerer, SpellListDruid);
+            RegisterSpell(BurstOfRadiance, SpellListCleric);
+            RegisterSpell(ThunderStrike, SpellListWizard, SpellListSorcerer, SpellListDruid);
+            RegisterSpell(EarthTremor, SpellListWizardGreenmage, SpellListWizard, SpellListSorcerer, SpellListDruid);
+            RegisterSpell(WinterBreath, SpellListWizardGreenmage, SpellListDruid);
         }
 
         private static SpellDefinition BuildAcidClaw()

--- a/SolastaCommunityExpansion/Spells/SRDSpells.cs
+++ b/SolastaCommunityExpansion/Spells/SRDSpells.cs
@@ -74,33 +74,33 @@ namespace SolastaCommunityExpansion.Spells
         internal static void Register()
         {
             // cantrip 
-            RegisterSpell(EldritchBlast, 1, WarlockSpellList);
+            RegisterSpell(EldritchBlast, WarlockSpellList);
 
             // 7th level
-            RegisterSpell(DivineWord, 0, SpellListCleric);
-            RegisterSpell(FingerOfDeath, 1, WarlockSpellList, WitchSpellList, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(ReverseGravity, 0, SpellListDruid, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(ConjureCelestial, 0, SpellListCleric);
+            RegisterSpell(DivineWord, SpellListCleric);
+            RegisterSpell(FingerOfDeath, WarlockSpellList, WitchSpellList, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(ReverseGravity, SpellListDruid, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(ConjureCelestial, SpellListCleric);
 
             // 8th level
-            RegisterSpell(DominateMonster, 1, WarlockSpellList, SpellListWizard, SpellListSorcerer, WitchSpellList);
-            RegisterSpell(Feeblemind, 1, WarlockSpellList, SpellListWizard, SpellListDruid, WitchSpellList);
-            RegisterSpell(HolyAura, 0, SpellListCleric);
-            RegisterSpell(IncendiaryCloud, 0, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(Maze, 0, SpellListWizard);
-            RegisterSpell(MindBlank, 0, SpellListWizard, WitchSpellList);
-            RegisterSpell(PowerWordStun, 1, WarlockSpellList, SpellListWizard, SpellListSorcerer, WitchSpellList);
-            RegisterSpell(SunBurst, 0, SpellListDruid, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(DominateMonster, WarlockSpellList, SpellListWizard, SpellListSorcerer, WitchSpellList);
+            RegisterSpell(Feeblemind, WarlockSpellList, SpellListWizard, SpellListDruid, WitchSpellList);
+            RegisterSpell(HolyAura, SpellListCleric);
+            RegisterSpell(IncendiaryCloud, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(Maze, SpellListWizard);
+            RegisterSpell(MindBlank, SpellListWizard, WitchSpellList);
+            RegisterSpell(PowerWordStun, WarlockSpellList, SpellListWizard, SpellListSorcerer, WitchSpellList);
+            RegisterSpell(SunBurst, SpellListDruid, SpellListWizard, SpellListSorcerer);
 
             // 9th level
-            RegisterSpell(Foresight, 1, WarlockSpellList, SpellListDruid, SpellListWizard, WitchSpellList);
-            RegisterSpell(MassHeal, 0, SpellListCleric);
-            RegisterSpell(MeteorSwarmSingleTarget, 0, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(PowerWordHeal, 0, SpellListCleric);
-            RegisterSpell(PowerWordKill, 1, WarlockSpellList, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(TimeStop, 0, SpellListWizard, SpellListSorcerer);
-            RegisterSpell(Shapechange, 0, SpellListDruid, SpellListWizard);
-            RegisterSpell(Weird, 1, WarlockSpellList, SpellListWizard, WitchSpellList);
+            RegisterSpell(Foresight, WarlockSpellList, SpellListDruid, SpellListWizard, WitchSpellList);
+            RegisterSpell(MassHeal, SpellListCleric);
+            RegisterSpell(MeteorSwarmSingleTarget, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(PowerWordHeal, SpellListCleric);
+            RegisterSpell(PowerWordKill, WarlockSpellList, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(TimeStop, SpellListWizard, SpellListSorcerer);
+            RegisterSpell(Shapechange, SpellListDruid, SpellListWizard);
+            RegisterSpell(Weird, WarlockSpellList, SpellListWizard, WitchSpellList);
         }
 
         //


### PR DESCRIPTION
I noticed some custom spells missing from the Spells Display. It turns out that there was a "MinimumSpells" dictionary that is no longer fully implemented. Spells were divided between that dictionary and the SuggestedSpells dictionary by the "suggestedStartsAt" variable in RegisterSpell(). But since the MinimumSpells dictionary isn't used for the display anymore those spells were not being listed. I removed the MinimumSpells dictionary and the suggestedStartsAt variable and now all the spells are available. For example, attached is a before and after of the Warlock spell list
![WarlockBeforeAndAfter](https://user-images.githubusercontent.com/86208060/164590252-ab24101b-208a-4625-ad33-27495b8ab737.PNG)
.