### PR TITLE
Improve custom code feature removal

### DIFF
--- a/SolastaCommunityExpansion/CustomDefinitions/FeatureDefinitionRemoveGrantedFeature.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/FeatureDefinitionRemoveGrantedFeature.cs
@@ -17,7 +17,7 @@
         public CharacterSubclassDefinition CharacterSubclass { get; set; }
         private string Tag => CharacterSubclass == null ? AttributeDefinitions.GetClassTag(CharacterClass, ClassLevel) : AttributeDefinitions.GetSubclassTag(CharacterClass, ClassLevel, CharacterSubclass);
 
-        public void ApplyFeature(RulesetCharacterHero hero)
+        public void ApplyFeature(RulesetCharacterHero hero, string tag)
         {
             var activeFeatures = hero.ActiveFeatures;
 
@@ -27,7 +27,7 @@
             }
         }
 
-        public void RemoveFeature(RulesetCharacterHero hero)
+        public void RemoveFeature(RulesetCharacterHero hero, string tag)
         {
             var activeFeatures = hero.ActiveFeatures;
 

--- a/SolastaCommunityExpansion/CustomDefinitions/IFeatureDefinitionCustomCode.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/IFeatureDefinitionCustomCode.cs
@@ -3,9 +3,9 @@
     public interface IFeatureDefinitionCustomCode
     {
         // Use this to add the feature to the character.
-        public void ApplyFeature(RulesetCharacterHero hero);
+        public void ApplyFeature(RulesetCharacterHero hero, string tag);
 
         // Use this to remove the feature from the character. In particular this is used to allow level down functionality.
-        public void RemoveFeature(RulesetCharacterHero hero);
+        public void RemoveFeature(RulesetCharacterHero hero, string tag);
     }
 }

--- a/SolastaCommunityExpansion/Feats/ZappaFeats.cs
+++ b/SolastaCommunityExpansion/Feats/ZappaFeats.cs
@@ -507,7 +507,7 @@ namespace SolastaCommunityExpansion.Feats
 
         public MetamagicOptionDefinition MetamagicOption { get; set; }
 
-        public void ApplyFeature(RulesetCharacterHero hero)
+        public void ApplyFeature(RulesetCharacterHero hero, string tag)
         {
             if (!hero.MetamagicFeatures.ContainsKey(MetamagicOption))
             {
@@ -517,7 +517,7 @@ namespace SolastaCommunityExpansion.Feats
             }
         }
 
-        public void RemoveFeature(RulesetCharacterHero hero)
+        public void RemoveFeature(RulesetCharacterHero hero, string tag)
         {
             if (MetamagicTrained)
             {

--- a/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
+++ b/SolastaCommunityExpansion/Level20/Features/PrimalChampionBuilder.cs
@@ -25,7 +25,7 @@ namespace SolastaCommunityExpansion.Level20.Features
 
     internal sealed class PrimalChampion : FeatureDefinition, IFeatureDefinitionCustomCode
     {
-        public void ApplyFeature(RulesetCharacterHero hero)
+        public void ApplyFeature(RulesetCharacterHero hero, string tag)
         {
             ModifyAttributeAndMax(hero, AttributeDefinitions.Strength, 4);
             ModifyAttributeAndMax(hero, AttributeDefinitions.Constitution, 4);
@@ -33,7 +33,7 @@ namespace SolastaCommunityExpansion.Level20.Features
             hero.RefreshAll();
         }
 
-        public void RemoveFeature(RulesetCharacterHero hero)
+        public void RemoveFeature(RulesetCharacterHero hero, string tag)
         {
             ModifyAttributeAndMax(hero, AttributeDefinitions.Strength, -4);
             ModifyAttributeAndMax(hero, AttributeDefinitions.Constitution, -4);

--- a/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
@@ -8,17 +8,17 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class CustomFeaturesContext
     {
-        internal static void RecursiveGrantCustomFeatures(RulesetCharacterHero hero, List<FeatureDefinition> features)
+        internal static void RecursiveGrantCustomFeatures(RulesetCharacterHero hero, List<FeatureDefinition> features, string tag)
         {
             foreach (var grantedFeature in features)
             {
                 if (grantedFeature is FeatureDefinitionFeatureSet set && set.Mode == FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                 {
-                    RecursiveGrantCustomFeatures(hero, set.FeatureSet);
+                    RecursiveGrantCustomFeatures(hero, set.FeatureSet, tag);
                 }
                 if (grantedFeature is IFeatureDefinitionCustomCode customFeature)
                 {
-                    customFeature.ApplyFeature(hero);
+                    customFeature.ApplyFeature(hero, tag);
                 }
                 if (grantedFeature is not FeatureDefinitionProficiency featureDefinitionProficiency)
                 {
@@ -32,17 +32,17 @@ namespace SolastaCommunityExpansion.Models
             }
         }
 
-        internal static void RecursiveRemoveCustomFeatures(RulesetCharacterHero hero, List<FeatureDefinition> features)
+        internal static void RecursiveRemoveCustomFeatures(RulesetCharacterHero hero, List<FeatureDefinition> features, string tag)
         {
             foreach (var grantedFeature in features)
             {
                 if (grantedFeature is FeatureDefinitionFeatureSet set && set.Mode == FeatureDefinitionFeatureSet.FeatureSetMode.Union)
                 {
-                    RecursiveRemoveCustomFeatures(hero, set.FeatureSet);
+                    RecursiveRemoveCustomFeatures(hero, set.FeatureSet, tag);
                 }
                 if (grantedFeature is IFeatureDefinitionCustomCode customFeature)
                 {
-                    customFeature.RemoveFeature(hero);
+                    customFeature.RemoveFeature(hero, tag);
                 }
                 if (grantedFeature is not FeatureDefinitionProficiency featureDefinitionProficiency)
                 {

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/CharacterBuildingManagerPatcher.cs
@@ -12,17 +12,22 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.RecursiveGrantCustomF
         /**
          * When a character is being granted features, this patch will apply the effect of custom features.
          */
-
-        internal static void Postfix(RulesetCharacterHero hero, List<FeatureDefinition> grantedFeatures, bool clearPrevious = true)
+        internal static void Postfix(RulesetCharacterHero hero, List<FeatureDefinition> grantedFeatures)
         {
-            if (!clearPrevious)
-            {
-                CustomFeaturesContext.RecursiveGrantCustomFeatures(hero, grantedFeatures);
-            }
-            else
-            {
-                CustomFeaturesContext.RecursiveRemoveCustomFeatures(hero, grantedFeatures);              
-            }
+            CustomFeaturesContext.RecursiveGrantCustomFeatures(hero, grantedFeatures);
+        }
+    }
+
+    [HarmonyPatch(typeof(CharacterBuildingManager), "ClearPrevious")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharacterBuildingManager_ClearPrevious
+    {
+        internal static void Prefix(RulesetCharacterHero hero, string tag)
+        {
+            if (string.IsNullOrEmpty(tag) || !hero.ActiveFeatures.ContainsKey(tag))
+                return;
+
+            CustomFeaturesContext.RecursiveRemoveCustomFeatures(hero, hero.ActiveFeatures[tag]);
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/CharacterBuildingManagerPatcher.cs
@@ -12,9 +12,9 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.RecursiveGrantCustomF
         /**
          * When a character is being granted features, this patch will apply the effect of custom features.
          */
-        internal static void Postfix(RulesetCharacterHero hero, List<FeatureDefinition> grantedFeatures)
+        internal static void Postfix(RulesetCharacterHero hero, List<FeatureDefinition> grantedFeatures, string tag)
         {
-            CustomFeaturesContext.RecursiveGrantCustomFeatures(hero, grantedFeatures);
+            CustomFeaturesContext.RecursiveGrantCustomFeatures(hero, grantedFeatures, tag);
         }
     }
 
@@ -27,7 +27,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.RecursiveGrantCustomF
             if (string.IsNullOrEmpty(tag) || !hero.ActiveFeatures.ContainsKey(tag))
                 return;
 
-            CustomFeaturesContext.RecursiveRemoveCustomFeatures(hero, hero.ActiveFeatures[tag]);
+            CustomFeaturesContext.RecursiveRemoveCustomFeatures(hero, hero.ActiveFeatures[tag], tag);
         }
     }
 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/RecursiveGrantCustomFeatures/RulesetCharacterHeroPatcher.cs
@@ -12,7 +12,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.RecursiveGrantCustomF
         {
             foreach(var feat in feats)
             {
-                Models.CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features);
+                Models.CustomFeaturesContext.RecursiveGrantCustomFeatures(__instance, feat.Features, null);
             }
         }
     }

--- a/SolastaMulticlass/Models/LevelDownContext.cs
+++ b/SolastaMulticlass/Models/LevelDownContext.cs
@@ -335,7 +335,7 @@ namespace SolastaMulticlass.Models
                 }
                 else if (featureDefinition is IFeatureDefinitionCustomCode featureDefinitionCustomCode)
                 {
-                    featureDefinitionCustomCode.RemoveFeature(hero);
+                    featureDefinitionCustomCode.RemoveFeature(hero, tag);
                 }
             }
         }


### PR DESCRIPTION
Remove custom features when `ClearPrevious` is called, instea of on `GrantFeatures` with _clearPrevious_ flag set. Old behavior removed features that were supposed to be added, and didn't remove ones that were supposed to be removed.
Also added tag toAdded/.Removed of `IFeatureDefinitionCustomCode` in case some feature would prefer knowing tag it was added/removed under.