### PR TITLE
Fixes for various issues

### DIFF
--- a/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
@@ -178,6 +178,7 @@ namespace SolastaCommunityExpansion.Models
                 }
             }
 
+            var selectedClass = LevelUpContext.GetSelectedClass(hero);
             foreach (var e in hero.ActiveFeatures)
             {
                 var tag = e.Key;
@@ -185,8 +186,12 @@ namespace SolastaCommunityExpansion.Models
 
                 if (features.Contains(feature))
                 {
-                    RecursiveRemoveCustomFeatures(hero, tag, new List<FeatureDefinition> { feature }, handleCustomCode: false);
-
+                    var featuresToRemove = new List<FeatureDefinition> { feature };
+                    RecursiveRemoveCustomFeatures(hero, tag, featuresToRemove, handleCustomCode: false);
+                    if (selectedClass != null)
+                    {
+                        RemoveFeatures(hero, selectedClass, tag, featuresToRemove);
+                    }
                     features.Remove(feature);
                     break;
                 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/PactMagic/CharacterReactionSubitemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/PactMagic/CharacterReactionSubitemPatcher.cs
@@ -23,13 +23,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.PactMagic
 
             MulticlassGameUiContext.PaintPactSlots(
                 heroWithSpellRepertoire, totalSlotsCount, totalSlotsRemainingCount, slotLevel, ___slotStatusTable);
-
-            var warlockSpellLevel = SharedSpellsContext.GetWarlockSpellLevel(heroWithSpellRepertoire);
-
-            if (!SharedSpellsContext.IsMulticaster(heroWithSpellRepertoire) && warlockSpellLevel != slotLevel)
-            {
-                ___canvasGroup.gameObject.SetActive(false);
-            }
         }
     }
 

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/PactMagic/ReactionRequestCastSpellPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/PactMagic/ReactionRequestCastSpellPatcher.cs
@@ -1,0 +1,52 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using HarmonyLib;
+using SolastaCommunityExpansion.Models;
+
+namespace SolastaCommunityExpansion.Patches.CustomFeatures.PactMagic
+{
+    
+    //Removes low-level sub-option for spell reactions if caster is not-multiclassed warlock
+    internal static class ReactionRequestCastSpellPatcher
+    {
+        [HarmonyPatch(typeof(ReactionRequestCastSpell), "BuildSlotSubOptions")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+        internal static class ReactionRequestCastSpell_BuildSlotSubOptions
+        {
+            public static void Postfix(ReactionRequestCastSpell __instance)
+            {
+                var hero = __instance.Character.RulesetCharacter as RulesetCharacterHero;
+                if (hero == null) { return; }
+
+                var warlockSpellLevel = SharedSpellsContext.GetWarlockSpellLevel(hero);
+                if (SharedSpellsContext.IsMulticaster(hero) || warlockSpellLevel == 0) { return; }
+
+                var rulesetEffect = __instance.ReactionParams.RulesetEffect as RulesetEffectSpell;
+                if (rulesetEffect == null) { return; }
+
+                var minSpellLebvel = rulesetEffect.SpellDefinition.SpellLevel;
+                var selected = false;
+                var optionsAvailability = __instance.SubOptionsAvailability;
+                var levels = optionsAvailability.Keys.ToList();
+
+                foreach (var spellLevel in levels)
+                {
+                    if (spellLevel != warlockSpellLevel)
+                    {
+                        optionsAvailability.Remove(spellLevel);
+                    }
+                    else if (!selected && optionsAvailability[spellLevel])
+                    {
+                        __instance.SelectSubOption(spellLevel - minSpellLebvel);
+                        selected = true;
+                    }
+                }
+
+                if (!selected)
+                {
+                    __instance.SelectSubOption(optionsAvailability.Keys.Min() - minSpellLebvel);
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
-using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Patches.GameUi.LevelUp
 {
@@ -21,16 +18,4 @@ namespace SolastaCommunityExpansion.Patches.GameUi.LevelUp
         }
     }
 
-    // avoids a restart when enabling / disabling classes on the Mod UI panel
-    [HarmonyPatch(typeof(CharacterStageClassSelectionPanel), "OnBeginShow")]
-    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
-    internal static class CharacterStageClassSelectionPanel_OnBeginShow
-    {
-        internal static void Prefix(List<CharacterClassDefinition> ___compatibleClasses)
-        {
-            var visibleClasses = DatabaseRepository.GetDatabase<CharacterClassDefinition>().Where(x => !x.GuiPresentation.Hidden);
-
-            ___compatibleClasses.SetRange(visibleClasses.OrderBy(x => x.FormatTitle()));
-        }
-    }
 }

--- a/SolastaCommunityExpansion/Patches/Multiclass/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Multiclass/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using SolastaCommunityExpansion.Models;
+using SolastaModApi.Infrastructure;
 using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.Multiclass.LevelUp
@@ -19,6 +21,11 @@ namespace SolastaCommunityExpansion.Patches.Multiclass.LevelUp
             List<CharacterClassDefinition> ___compatibleClasses,
             ref int ___selectedClass)
         {
+            // avoids a restart when enabling / disabling classes on the Mod UI panel
+            var visibleClasses = DatabaseRepository.GetDatabase<CharacterClassDefinition>().Where(x => !x.GuiPresentation.Hidden);
+
+            ___compatibleClasses.SetRange(visibleClasses.OrderBy(x => x.FormatTitle()));
+            
             if (!Main.Settings.EnableMulticlass)
             {
                 return;


### PR DESCRIPTION
moved patch that allows selecting/deselecting available classes without restart to the MC patch, to make sure it is not called after and overwrites filtered classes with all classes on levelup 