### PR TITLE
Fix missing cantrips on replace

### DIFF
--- a/SolastaCommunityExpansion/Models/LevelDownContext.cs
+++ b/SolastaCommunityExpansion/Models/LevelDownContext.cs
@@ -7,6 +7,8 @@ namespace SolastaCommunityExpansion.Models
 {
     internal static class LevelDownContext
     {
+        public static bool IsLevelDown { get; set; } = false;
+
         public class FunctorLevelDown : Functor
         {
             public override IEnumerator Execute(
@@ -89,6 +91,8 @@ namespace SolastaCommunityExpansion.Models
             var classTag = AttributeDefinitions.GetClassTag(characterClassDefinition, classLevel);
             var subclassTag = string.Empty;
 
+            IsLevelDown = true;
+
             var characterBuildingService = ServiceRepository.GetService<ICharacterBuildingService>();
 
             characterBuildingService.LevelUpCharacter(hero, false);
@@ -125,6 +129,8 @@ namespace SolastaCommunityExpansion.Models
             {
                 ServiceRepository.GetService<ICharacterPoolService>().SaveCharacter(hero, true);
             }
+            
+            IsLevelDown = false;
         }
 
         private static void UnlearnSpells(RulesetCharacterHero hero, int indexLevel)

--- a/SolastaCommunityExpansion/Patches/Bugfix/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Bugfix/CharacterBuildingManagerPatcher.cs
@@ -20,19 +20,19 @@ namespace SolastaCommunityExpansion.Patches.BugFix
                 return true;
             }
 
-            var defaultTag = CustomFeaturesContext.UnCustomizeTag(tag);
+            var spellTag = CustomFeaturesContext.GetSpellLearningTag(heroBuildingData.HeroCharacter);
 
             foreach (FeatureDefinition grantedFeature in grantedFeatures)
             {
                 switch (grantedFeature)
                 {
                     case FeatureDefinitionCastSpell spell:
-                        __instance.SetupSpellPointPools(heroBuildingData, spell, defaultTag);
+                        __instance.SetupSpellPointPools(heroBuildingData, spell, spellTag);
                         continue; // In original code this was 'return'
                     case FeatureDefinitionBonusCantrips cantrips:
                         foreach (var cantrip in cantrips.BonusCantrips)
                         {
-                            __instance.AcquireBonusCantrip(heroBuildingData, cantrip, defaultTag);
+                            __instance.AcquireBonusCantrip(heroBuildingData, cantrip, spellTag);
                         }
                         continue;
                     case FeatureDefinitionProficiency proficiency:

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CharacterBuildingManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CharacterBuildingManagerPatcher.cs
@@ -125,14 +125,25 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
     internal static class CharacterBuildingManager_ClearPrevious
     {
+        private static readonly List<FeatureDefinition> ToRemove = new();
         internal static void Prefix(RulesetCharacterHero hero, string tag)
         {
+            ToRemove.Clear();
             if (string.IsNullOrEmpty(tag) || !hero.ActiveFeatures.ContainsKey(tag))
             {
                 return;
             }
-
-            CustomFeaturesContext.RecursiveRemoveCustomFeatures(hero, tag, hero.ActiveFeatures[tag]);
+            ToRemove.AddRange(hero.ActiveFeatures[tag]);
+        }
+        
+        internal static void Postfix(RulesetCharacterHero hero, string tag)
+        {
+            if (ToRemove.Empty())
+            {
+                return;
+            }
+            //TODO: check if other places where this is called require same prefx/postfix treatment
+            CustomFeaturesContext.RecursiveRemoveCustomFeatures(hero, tag, ToRemove);
         }
     }
 

--- a/SolastaCommunityExpansion/Patches/Multiclass/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Multiclass/LevelUp/CharacterStageClassSelectionPanelPatcher.cs
@@ -54,6 +54,20 @@ namespace SolastaCommunityExpansion.Patches.Multiclass.LevelUp
             }
         }
     }
+    
+    // reset IsClassSelectionStage for hero
+    [HarmonyPatch(typeof(CharacterStageClassSelectionPanel), "OnEndHide")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class CharacterStageClassSelectionPanel_OnEndHide
+    {
+        internal static void Prefix(RulesetCharacterHero ___currentHero)
+        {
+            if (___currentHero != null && LevelUpContext.IsLevelingUp(___currentHero))
+            {
+                LevelUpContext.SetIsClassSelectionStage(___currentHero, false);
+            }
+        }
+    }
 
     // hide the equipment panel group
     [HarmonyPatch(typeof(CharacterStageClassSelectionPanel), "Refresh")]


### PR DESCRIPTION
Fixed cantrips missing if you replaced them and then rest replacement
Fixed cantips not properly returning after leveld down removes their replacent
Fixed `LevelupContext.IsClassSelectionStage` not being reset if levelup scren is closed on class selection panel