### PR TITLE
Fix eldritch smite

### DIFF
--- a/SolastaCommunityExpansion/Api/AdditionalExtensions/CustomizedFeatureDefinitions.cs
+++ b/SolastaCommunityExpansion/Api/AdditionalExtensions/CustomizedFeatureDefinitions.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using SolastaModApi.Infrastructure;
+
+namespace SolastaCommunityExpansion.Api.AdditionalExtensions
+{
+    public static class CustomizedFeatureDefinitions
+    {
+        private static readonly Dictionary<FeatureDefinition, List<object>> CustomFeatures = new();
+
+        private static List<object> GetOrCreateForKey(FeatureDefinition feature)
+        {
+            if (!CustomFeatures.ContainsKey(feature))
+            {
+                CustomFeatures.Add(feature, new List<object>());
+            }
+
+            return CustomFeatures[feature];
+        }
+
+        private static List<object> GetForKey(FeatureDefinition feature)
+        {
+            if (!CustomFeatures.ContainsKey(feature))
+            {
+                return null;
+            }
+
+            return CustomFeatures[feature];
+        }
+
+        public static T SetCustomFeatures<T>(this T feature, params object[] features) where T : FeatureDefinition
+        {
+            GetOrCreateForKey(feature).SetRange(features);
+            return feature;
+        }
+
+        public static IEnumerable<T> GetCustomFeaturesOfType<T>(this FeatureDefinition feature) where T : class
+        {
+            return GetForKey(feature)?.OfType<T>();
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Classes/Warlock/Features/EldritchInvocationsBuilder.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Features/EldritchInvocationsBuilder.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using SolastaCommunityExpansion.Api.AdditionalExtensions;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Builders.Features;
 using SolastaCommunityExpansion.Classes.Warlock.Subclasses;
 using SolastaCommunityExpansion.CustomDefinitions;
 using SolastaCommunityExpansion.Models;
+using SolastaCommunityExpansion.Utils;
 using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 using UnityEngine.AddressableAssets;
@@ -477,8 +479,26 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Features
             
             ((FeatureDefinitionFeatureSetWithPreRequisites)EldritchInvocations["ImprovedPactWeapon"]).Validators.SetRange(RequirePactOfTheBlade);
 
-            ((FeatureDefinitionFeatureSet)EldritchInvocations["EldritchSmite"]).FeatureSet
-                .Add(FeatureDefinitionAdditionalDamages.AdditionalDamagePaladinDivineSmite);
+            var eldritchSmite = FeatureDefinitionAdditionalDamageBuilder
+                .Create("WarlockEldritchSmiteDamage", DefinitionBuilder.CENamespaceGuid)
+                .Configure("EldritchSmite",
+                    RuleDefinitions.FeatureLimitedUsage.OncePerTurn,
+                    RuleDefinitions.AdditionalDamageValueDetermination.Die,
+                    RuleDefinitions.AdditionalDamageTriggerCondition.SpendSpellSlot,
+                    RuleDefinitions.AdditionalDamageRequiredProperty.None,
+                    true,
+                    RuleDefinitions.DieType.D8,
+                    0,
+                    RuleDefinitions.AdditionalDamageType.Specific,
+                    RuleDefinitions.DamageTypeForce,
+                    RuleDefinitions.AdditionalDamageAdvancement.SlotLevel,
+                    DiceByRankMaker.MakeBySteps(start: 0, increment: 1, step: 0)
+                )
+                .AddToDB();
+
+            eldritchSmite.SetCustomFeatures(new WarlockClassHolder());
+            
+            ((FeatureDefinitionFeatureSet)EldritchInvocations["EldritchSmite"]).FeatureSet.Add(eldritchSmite);
             ((FeatureDefinitionFeatureSetWithPreRequisites)EldritchInvocations["EldritchSmite"]).Validators.SetRange(RequirePactOfTheBlade);
 
             ((FeatureDefinitionFeatureSet)EldritchInvocations["ThirstingBlade"]).FeatureSet
@@ -563,5 +583,10 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Features
                     FeatureDefinitionSenses.SenseDarkvision24
                 );
         }
+    }
+
+    internal class WarlockClassHolder : IClassHoldingFeature
+    {
+        public CharacterClassDefinition Class => Warlock.ClassWarlock;
     }
 }

--- a/SolastaCommunityExpansion/CustomDefinitions/CustomSpells.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/CustomSpells.cs
@@ -4,14 +4,9 @@ using SolastaModApi.Extensions;
 
 namespace SolastaCommunityExpansion.CustomDefinitions
 {
-    public class SpellWithCustomFeatures : SpellDefinition, ISpellWithCustomFeatures
+    public class SpellWithCustomFeatures : SpellDefinition, IDefinitionWithCustomFeatures
     {
         public List<object> CustomFeatures { get; } = new();
-
-        public IEnumerable<T> GetTypedFeatures<T>() where T : class
-        {
-            return CustomFeatures.Select(f => f as T);
-        }
     }
 
     public class SpellWithCasterFeatureDependentEffects : SpellWithCustomFeatures, ICustomMagicEffectBasedOnCaster

--- a/SolastaCommunityExpansion/CustomDefinitions/IDefinitionWithCustomFeatures.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/IDefinitionWithCustomFeatures.cs
@@ -2,10 +2,8 @@
 
 namespace SolastaCommunityExpansion.CustomDefinitions
 {
-    public interface ISpellWithCustomFeatures
+    public interface IDefinitionWithCustomFeatures
     {
         List<object> CustomFeatures { get; }
-
-        public IEnumerable<T> GetTypedFeatures<T>() where T: class;
     }
 }

--- a/SolastaCommunityExpansion/CustomDefinitions/ReactionRequestSpendSpellSlotExtended.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/ReactionRequestSpendSpellSlotExtended.cs
@@ -1,0 +1,50 @@
+﻿using SolastaCommunityExpansion.Models;
+
+namespace SolastaCommunityExpansion.CustomDefinitions
+{
+    public class ReactionRequestSpendSpellSlotExtended : ReactionRequest
+    {
+        private readonly GuiCharacter _guiCharacter;
+
+        public ReactionRequestSpendSpellSlotExtended(CharacterActionParams actionParams)
+            : base("SpendSpellSlot", actionParams)
+        {
+            SubOptionsAvailability.Clear();
+
+            var hero = actionParams.ActingCharacter.RulesetCharacter as RulesetCharacterHero;
+            var spellRepertoire = ReactionParams.SpellRepertoire;
+            
+            var selected = MulticlassGameUiContext.AddAvailableSubLevels(SubOptionsAvailability, hero, spellRepertoire, 1);
+            if (selected >= 0)
+            {
+                SelectSubOption(selected);
+            }
+            _guiCharacter = new GuiCharacter(Character);
+        }
+
+        public override int SelectedSubOption => ReactionParams.IntParameter - 1;
+
+        public override string SuboptionTag => ReactionParams.StringParameter;
+
+        public override void SelectSubOption(int option) => ReactionParams.IntParameter = option + 1;
+
+        public override string FormatTitle() => Gui.Localize(string.Format(
+            DatabaseRepository.GetDatabase<ReactionDefinition>().GetElement(DefinitionName).GuiPresentation.Title,
+            ReactionParams.StringParameter));
+
+        public override string FormatDescription() => Gui.Format(
+            string.Format(
+                DatabaseRepository.GetDatabase<ReactionDefinition>().GetElement(DefinitionName).GuiPresentation
+                    .Description, ReactionParams.StringParameter), _guiCharacter.Name);
+
+        public override string FormatReactTitle() => Gui.Format(
+            string.Format(
+                DatabaseRepository.GetDatabase<ReactionDefinition>().GetElement(DefinitionName).ReactTitle,
+                ReactionParams.StringParameter), _guiCharacter.Name);
+
+        public override string FormatReactDescription() => Gui.Format(
+            string.Format(
+                DatabaseRepository.GetDatabase<ReactionDefinition>().GetElement(DefinitionName).ReactDescription,
+                ReactionParams.StringParameter), _guiCharacter.Name);
+    }
+}

--- a/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
@@ -360,5 +360,24 @@ namespace SolastaCommunityExpansion.Models
         {
             return UnCustomizeTag(tag) + "[Custom]";
         }
+
+        /**Returns first custom feature it finds within this definition.*/
+        public static T GetFirstCustomFeature<T>(BaseDefinition definition) where T : class
+        {
+            if (definition == null) { return null; }
+
+            if (definition is T custom)
+            {
+                return custom;
+            }
+
+            if (definition is IDefinitionWithCustomFeatures container)
+            {
+                return container.CustomFeatures.OfType<T>().FirstOrDefault();
+            }
+
+            return null;
+        }
+        //TODO: add another method to get all custom features from definition
     }
 }

--- a/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomFeaturesContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using SolastaCommunityExpansion.Api.AdditionalExtensions;
 using SolastaCommunityExpansion.CustomDefinitions;
 using SolastaModApi.Extensions;
 using UnityEngine;
@@ -371,12 +372,19 @@ namespace SolastaCommunityExpansion.Models
                 return custom;
             }
 
+            T result = null;
+            
             if (definition is IDefinitionWithCustomFeatures container)
             {
-                return container.CustomFeatures.OfType<T>().FirstOrDefault();
+                result = container.CustomFeatures.OfType<T>().FirstOrDefault();
             }
 
-            return null;
+            if (result == null && definition is FeatureDefinition feature)
+            {
+                result = feature.GetCustomFeaturesOfType<T>()?.FirstOrDefault();
+            }
+
+            return result;
         }
         //TODO: add another method to get all custom features from definition
     }

--- a/SolastaCommunityExpansion/Models/CustomReactionsContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomReactionsContext.cs
@@ -60,14 +60,15 @@ namespace SolastaCommunityExpansion.Models
 
             ruleDefender.InvokeMethod("EnumerateUsableSpells");
 
+            //TODO: refactor this a bit so custom features are not browsed twice
             var spells = ruleDefender.UsableSpells
                 .OfType<SpellWithCustomFeatures>()
-                .Where(s => s.GetTypedFeatures<IDamagedReactionSpell>().Any())
+                .Where(s => s.CustomFeatures.OfType<IDamagedReactionSpell>().Any())
                 .ToList();
 
             foreach (var spell in spells)
             {
-                var reactions = spell.GetTypedFeatures<IDamagedReactionSpell>();
+                var reactions = spell.CustomFeatures.OfType<IDamagedReactionSpell>().ToList();
 
                 if (reactions.Any(r => r.CanReact(attacker, defender, attackModifier, attackMode, rangedAttack,
                         advantageType, actualEffectForms, rulesetEffect, criticalHit, firstTarget)))

--- a/SolastaCommunityExpansion/Models/MulticlassGameUiContext.cs
+++ b/SolastaCommunityExpansion/Models/MulticlassGameUiContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using SolastaModApi.Infrastructure;
 using UnityEngine;
@@ -118,6 +119,45 @@ namespace SolastaCommunityExpansion.Models
 
                 component.Available.GetComponent<Image>().color = WhiteSlot;
             }
+        }
+
+        /**Adds available slot level options to optionsAvailability and returns index of pre-picked option, or -1*/
+        public static int AddAvailableSubLevels(Dictionary<int, bool> optionsAvailability, RulesetCharacterHero hero,
+            RulesetSpellRepertoire spellRepertoire, int minSpellLebvel = 1)
+        {
+            var selectedSlot = -1;
+
+            var warlockSpellLevel = SharedSpellsContext.GetWarlockSpellLevel(hero);
+            var shortRestSlotsCount = SharedSpellsContext.GetWarlockMaxSlots(hero);
+            var isMulticaster = SharedSpellsContext.IsMulticaster(hero);
+            var hasPactMagic = warlockSpellLevel > 0;
+
+            var maxRepertoireLevel = spellRepertoire.MaxSpellLevelOfSpellCastingLevel;
+            var maxSpellLevel = Math.Max(maxRepertoireLevel, warlockSpellLevel);
+            var selected = false;
+
+            for (int level = minSpellLebvel; level <= maxSpellLevel; ++level)
+            {
+                spellRepertoire.GetSlotsNumber(level, out var remaining, out var max);
+                if (hasPactMagic && level != warlockSpellLevel)
+                    max -= shortRestSlotsCount;
+
+                if (max > 0 && (
+                        level <= maxRepertoireLevel
+                        && (isMulticaster || !hasPactMagic)
+                        || level == warlockSpellLevel
+                    ))
+                {
+                    optionsAvailability.Add(level, remaining > 0);
+                    if (!selected && remaining > 0)
+                    {
+                        selected = true;
+                        selectedSlot = level - minSpellLebvel;
+                    }
+                }
+            }
+
+            return selectedSlot;
         }
 
         public static string GetAllClassesLabel(GuiCharacter character, char separator = '\n')

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/ClassHoldingFeature/RulesetCharacterHeroPatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using SolastaCommunityExpansion.CustomDefinitions;
+using SolastaCommunityExpansion.Models;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures.ClassHoldingFeature
 {
@@ -13,15 +14,17 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.ClassHoldingFeature
             FeatureDefinition featureDefinition,
             ref CharacterClassDefinition __result)
         {
-            if (featureDefinition is not IClassHoldingFeature overrideClassHoldingFeature || overrideClassHoldingFeature.Class == null)
+            var classHolder = CustomFeaturesContext.GetFirstCustomFeature<IClassHoldingFeature>(featureDefinition);
+            
+            if (classHolder == null || classHolder.Class == null)
             {
                 return;
             }
 
             // Only override if the character actually has levels in the class, to prevent errors
-            if (__instance.ClassesAndLevels.TryGetValue(overrideClassHoldingFeature.Class, out int levelsInClass) && levelsInClass > 0)
+            if (__instance.ClassesAndLevels.TryGetValue(classHolder.Class, out int levelsInClass) && levelsInClass > 0)
             {
-                __result = overrideClassHoldingFeature.Class;
+                __result = classHolder.Class;
             }
         }
     }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/OnCharacterAttackEffect/GameLocationBattleManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/OnCharacterAttackEffect/GameLocationBattleManagerPatcher.cs
@@ -176,6 +176,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.OnCharacterAttackEffe
                     // Trigger method
                     bool validTrigger = false;
                     bool validUses = true;
+                    bool validProperty = true;
                     if (provider.LimitedUsage != RuleDefinitions.FeatureLimitedUsage.None)
                     {
                         if (provider.LimitedUsage == RuleDefinitions.FeatureLimitedUsage.OnceInMyturn && (attacker.UsedSpecialFeatures.ContainsKey(featureDefinition.Name) || (__instance.Battle != null && __instance.Battle.ActiveContender != attacker)))
@@ -205,6 +206,12 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.OnCharacterAttackEffe
                     CharacterActionParams reactionParams = null;
                     if (validUses)
                     {
+                        // Check required properties if needed
+                        validProperty = ValidateProperty();
+                    }
+
+                    if (validUses && validProperty)
+                    {
                         // Typical for Sneak Attack
                         if (provider.TriggerCondition == RuleDefinitions.AdditionalDamageTriggerCondition.AdvantageOrNearbyAlly && attackMode != null)
                         {
@@ -219,7 +226,8 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.OnCharacterAttackEffe
                         //
                         //else if (provider.TriggerCondition == RuleDefinitions.AdditionalDamageTriggerCondition.SpendSpellSlot && attackModifier != null && attackModifier.Proximity == RuleDefinitions.AttackProximity.Melee)
                         else if (provider.TriggerCondition == RuleDefinitions.AdditionalDamageTriggerCondition.SpendSpellSlot
-                            && attackModifier != null && attackModifier.Proximity == RuleDefinitions.AttackProximity.Melee
+                            //TODO: make Divine Smite malee-only via properties
+                            //&& attackModifier != null && attackModifier.Proximity == RuleDefinitions.AttackProximity.Melee
                             && (!Main.Settings.EnableCtrlClickBypassSmiteReactionPanel || !isCtrlPressed))
                         {
                             // This is used to allow Divine Smite under Wildshape
@@ -384,6 +392,10 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.OnCharacterAttackEffe
                         }
                     }
 
+                    //Wrapped in no-formatting to simplify merges/changes from TA ------ START --------
+                    // @formatter:off
+                    bool ValidateProperty() {
+                    // ReSharper disable once VariableHidesOuterVariable
                     // Check required properties if needed
                     bool validProperty = true;
                     if (validTrigger && provider.RequiredProperty != RuleDefinitions.AdditionalDamageRequiredProperty.None && attackMode != null)
@@ -449,6 +461,10 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.OnCharacterAttackEffe
                         }
                     }
 
+                        return validProperty;
+                    }
+                    // @formatter:on
+                    //Wrapped in no-formatting to simplify merges/changes from TA ------ END --------
                     if (validTrigger && validProperty)
                     {
                         //__instance.ComputeAndNotifyAdditionalDamage(attacker, defender, provider, actualEffectForms, reactionParams, attackMode, criticalHit);

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/OnCharacterAttackEffect/GameLocationBattleManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/OnCharacterAttackEffect/GameLocationBattleManagerPatcher.cs
@@ -398,7 +398,7 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.OnCharacterAttackEffe
                     // ReSharper disable once VariableHidesOuterVariable
                     // Check required properties if needed
                     bool validProperty = true;
-                    if (validTrigger && provider.RequiredProperty != RuleDefinitions.AdditionalDamageRequiredProperty.None && attackMode != null)
+                    if (/*validTrigger &&*/ provider.RequiredProperty != RuleDefinitions.AdditionalDamageRequiredProperty.None && attackMode != null)
                     {
                         bool finesse = false;
                         bool melee = false;

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/PactMagic/ReactionRequestCastSpellPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/PactMagic/ReactionRequestCastSpellPatcher.cs
@@ -21,33 +21,14 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.PactMagic
                 var rulesetEffect = __instance.ReactionParams.RulesetEffect as RulesetEffectSpell;
                 if (rulesetEffect == null) { return true; }
                 
-                var warlockSpellLevel = SharedSpellsContext.GetWarlockSpellLevel(hero);
-                var isMulticaster = SharedSpellsContext.IsMulticaster(hero);
-                var hasPactMagic = warlockSpellLevel > 0;
-
                 __instance.SubOptionsAvailability.Clear();
                 var spellRepertoire = rulesetEffect.SpellRepertoire;
                 var minSpellLebvel = rulesetEffect.SpellDefinition.SpellLevel;
-                var maxRepertoireLevel = spellRepertoire.MaxSpellLevelOfSpellCastingLevel;
-                var maxSpellLevel = Math.Max(maxRepertoireLevel, warlockSpellLevel);
-                var selected = false;
 
-                for (int level = minSpellLebvel; level <= maxSpellLevel; ++level)
+                var selected = MulticlassGameUiContext.AddAvailableSubLevels(__instance.SubOptionsAvailability, hero, spellRepertoire, minSpellLebvel);
+                if (selected >= 0)
                 {
-                    spellRepertoire.GetSlotsNumber(level, out var remaining, out var max);
-                    if (max > 0 && (
-                            level <= maxRepertoireLevel
-                            && (isMulticaster || !hasPactMagic)
-                            || level == warlockSpellLevel
-                        ))
-                    {
-                        __instance.SubOptionsAvailability.Add(level, remaining > 0);
-                        if (!selected && remaining > 0)
-                        {
-                            selected = true;
-                            __instance.SelectSubOption(level - minSpellLebvel);
-                        }
-                    }
+                    __instance.SelectSubOption(selected);
                 }
 
                 return false;

--- a/SolastaCommunityExpansion/Patches/GameUi/Battle/GameLocationActionManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Battle/GameLocationActionManagerPatcher.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaCommunityExpansion.CustomDefinitions;
+using SolastaModApi.Infrastructure;
+
+namespace SolastaCommunityExpansion.Patches.GameUi.Battle
+{
+    internal static class GameLocationActionManagerPatcher
+    {
+        [HarmonyPatch(typeof(GameLocationActionManager), "ReactToSpendSpellSlot")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+        internal static class GameLocationActionManager_ReactToSpendSpellSlot
+        {
+            internal static bool Prefix(GameLocationActionManager __instance, CharacterActionParams reactionParams)
+            {
+                __instance.InvokeMethod("AddInterruptRequest",
+                    new ReactionRequestSpendSpellSlotExtended(reactionParams));
+                return false;
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -874,8 +874,16 @@ Feature/&EldritchBlastRepellingBlastBonusCantripTitle	Repelling Blast
 Feature/&EldritchMindDescription	You have advantage on Constitution saving throws that you make to maintain your concentration on a spell
 Feature/&EldritchMindTitle	Eldritch Mind
 Feature/&EldritchSightTitle	Eldritch Sight
-Feature/&EldritchSmiteDescription	Once per turn when you hit a creature with your pact weapon, you can expend a warlock spell slot to deal an extra 1d8 force damage to the target, plus another 1d8 per level of the spell slot,
+Feature/&EldritchSmiteDescription	Once per turn when you hit a creature with your pact weapon, you can expend a warlock spell slot to deal an extra 1d8 force damage to the target, plus another 1d8 per level of the spell slot.
 Feature/&EldritchSmiteTitle	Eldritch Smite
+Reaction/&SpendSpellSlotEldritchSmiteTitle	Eldritch Smite
+Reaction/&SpendSpellSlotEldritchSmiteDescription	{0} can spend spell slot to deal 1d8 + 1d8 force damage per slot level to the target.
+Reaction/&SpendSpellSlotEldritchSmiteReactTitle	Smite
+Reaction/&SpendSpellSlotEldritchSmiteReactDescription	Click to spend a spell slot and increase damage to the target.
+Reaction/&SubitemSelectEldritchSmiteTitle	Slot Level
+Reaction/&SubitemSelectEldritchSmiteDescription	Select a slot level to consume for your Eldritch Smite.
+Feedback/&AdditionalDamageEldritchSmiteFormat	Eldritch Smite!
+Feedback/&AdditionalDamageEldritchSmiteLine	{0} smites {1} (+{2})
 Feature/&ElementalistSpellsMagicAffinityDescription	You choose from an expanded list of spells when you learn a warlock spell. The following spells are added to the warlock spell list for you: {0}\n\n  
 Feature/&ElementalistSpellsMagicAffinityTitle	Elementalist Spells
 Feature/&ElementalPactAirPlane	Air Plane

--- a/SolastaCommunityExpansion/Utils/DiceByRankMaker.cs
+++ b/SolastaCommunityExpansion/Utils/DiceByRankMaker.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using SolastaModApi.Infrastructure;
+
+namespace SolastaCommunityExpansion.Utils
+{
+    public static class DiceByRankMaker
+    {
+        public static List<DiceByRank> Make(params (int, int)[] ranks)
+        {
+            return ranks
+                .Select((rank) => new DiceByRank().SetRank(rank.Item1).SetDices(rank.Item2))
+                .ToList();
+        }
+
+        public static List<DiceByRank> MakeBySteps(int start = 0, int increment = 1, int step = 0)
+        {
+            var result = new List<DiceByRank>();
+            for (int i = 0; i < 20; i++)
+            {
+                result.Add(new DiceByRank().SetRank(i).SetDices(start + ((i + 1) / (step + 1)) * increment));
+            }
+
+            return result;
+        }
+
+        public static DiceByRank SetRank(this DiceByRank instance, int rank)
+        {
+            instance.SetField("rank", rank);
+            return instance;
+        }
+
+        public static DiceByRank SetDices(this DiceByRank instance, int dices)
+        {
+            instance.SetField("diceNumber", dices);
+            return instance;
+        }
+    }
+}


### PR DESCRIPTION
 - Made `HandleCharacterAttackDamage` check weapon properties before triggers and made `SpendSpellSlot` trigger not require melee
 - made custom Eldritch Smite instead of directly using Divine Smite
 - replaced `ReactionRequestSpendSpellSlot` with `ReactionRequestSpendSpellSlotExtended` that properly calculates available slot otions