### PR TITLE
fixed character inspection crash

### DIFF
--- a/SolastaCommunityExpansion/Models/InspectionPanelContext.cs
+++ b/SolastaCommunityExpansion/Models/InspectionPanelContext.cs
@@ -10,12 +10,16 @@ namespace SolastaCommunityExpansion.Models
     {
         internal static int SelectedClassIndex { get; set; }
 
-        public static CharacterClassDefinition SelectedClass => Global.InspectedHero?.ClassesAndLevels.Keys.ElementAt(SelectedClassIndex);
+        public static CharacterClassDefinition SelectedClass => Global.InspectedHero?.ClassesAndLevels.Keys.ElementAtOrDefault(SelectedClassIndex);
 
-        public static string GetSelectedClassSearchTerm(string original) => original 
-            + SelectedClass == null 
-                ? string.Empty
-                : SelectedClass.Name;
+        public static string GetSelectedClassSearchTerm(string original)
+        {
+            var selectedClass = SelectedClass;
+            return original
+                   + (selectedClass == null
+                       ? string.Empty
+                       : selectedClass.Name);
+        }
 
         public static void EnumerateClassBadges(CharacterInformationPanel __instance)
         {

--- a/SolastaCommunityExpansion/Patches/GameUi/CharacterInspection/GuiCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/CharacterInspection/GuiCharacterPatcher.cs
@@ -16,9 +16,10 @@ namespace SolastaCommunityExpansion.Patches.GameUi.CharacterInspection
             }
 
             // NOTE: don't use SelectedClass??. which bypasses Unity object lifetime check
-            if (InspectionPanelContext.SelectedClass)
+            var selectedClass = InspectionPanelContext.SelectedClass;
+            if (selectedClass)
             {
-                __result = InspectionPanelContext.SelectedClass;
+                __result = selectedClass;
             }
         }
     }


### PR DESCRIPTION
fixed crash when trying to inspect character with less classes then selected class index of previously inspected character. Probably needs more work as it seems that buttos are not unbound properly.