### PR TITLE
Fix soulblade empower disappearing on location change

### DIFF
--- a/SolastaCommunityExpansion/Classes/Warlock/Subclasses/AHWarlockSubclassSoulBlade.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Subclasses/AHWarlockSubclassSoulBlade.cs
@@ -1,6 +1,7 @@
 ﻿using SolastaModApi.Extensions;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Builders.Features;
+using SolastaCommunityExpansion.CustomDefinitions;
 using static SolastaModApi.DatabaseHelper.FeatureDefinitionProficiencys;
 using static SolastaModApi.DatabaseHelper;
 using static SolastaModApi.DatabaseHelper.SpellDefinitions;
@@ -66,6 +67,7 @@ namespace SolastaCommunityExpansion.Classes.Warlock.Subclasses
                 .Create("AHWarlockSoulBladePactEmpowerWeaponPower", DefinitionBuilder.CENamespaceGuid)
                 .SetGuiPresentation(Category.Feature, FeatureDefinitionPowers.PowerOathOfDevotionSacredWeapon.GuiPresentation.SpriteReference)
                 .SetShortTitleOverride("Feature/&AHWarlockSoulBladePactEmpowerWeaponPowerTitle")
+                .SetCustomSubFeatures(SkipEffectRemovalOnLocationChange.Always)
                 .SetRechargeRate(RechargeRate.LongRest)
                 .SetFixedUsesPerRecharge(1)
                 .SetCostPerUse(1)

--- a/SolastaCommunityExpansion/CustomDefinitions/SkipEffectRemovalOnLocationChange.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/SkipEffectRemovalOnLocationChange.cs
@@ -1,0 +1,29 @@
+﻿namespace SolastaCommunityExpansion.CustomDefinitions
+{
+    public static class SkipEffectRemovalOnLocationChange
+    {
+        public static readonly ISKipEffectRemovalOnLocationChange Always = new AlwaysSkip();
+        public static readonly ISKipEffectRemovalOnLocationChange OnChained = new SkipOnChained();
+
+        private class AlwaysSkip : ISKipEffectRemovalOnLocationChange
+        {
+            public bool Skip(bool willEnterChainedLocation)
+            {
+                return true;
+            }
+        }
+
+        private class SkipOnChained : ISKipEffectRemovalOnLocationChange
+        {
+            public bool Skip(bool willEnterChainedLocation)
+            {
+                return willEnterChainedLocation;
+            }
+        }
+    }
+
+    public interface ISKipEffectRemovalOnLocationChange
+    {
+        public bool Skip(bool willEnterChainedLocation);
+    }
+}

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/GameLocationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/GameLocationManagerPatcher.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using HarmonyLib;
+using SolastaCommunityExpansion.Api.AdditionalExtensions;
+using SolastaCommunityExpansion.CustomDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.CustomFeatures
+{
+    internal static class GameLocationManagerPatcher
+    {
+        //prevent some effects from being removed when entering new location
+        [HarmonyPatch(typeof(GameLocationManager), "StopCharacterEffectsIfRelevant")]
+        class GameLocationManager_StopCharacterEffectsIfRelevant
+        {
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+            {
+                var codes = instructions.ToList();
+                var removeEffects = codes.FindIndex(x =>
+                    x.opcode == OpCodes.Callvirt && x.operand.ToString().Contains("Terminate"));
+                var maybeTerminate = new Action<RulesetEffect, bool, bool>(MaybeTerminate).Method;
+                codes[removeEffects] = new CodeInstruction(OpCodes.Call, maybeTerminate);
+                codes.Insert(removeEffects, new CodeInstruction(OpCodes.Ldarg_1));
+
+                return codes.AsEnumerable();
+            }
+
+            static void MaybeTerminate(RulesetEffect effect, bool self, bool willEnterChainedLocation)
+            {
+                var baseDefinition = effect.SourceDefinition;
+                if (baseDefinition != null)
+                {
+                    var skip = baseDefinition.GetFirstSubFeatureOfType<ISKipEffectRemovalOnLocationChange>();
+                    if (skip != null && skip.Skip(willEnterChainedLocation))
+                    {
+                        return;
+                    }
+                }
+
+                effect.Terminate(self);
+            }
+        }
+    }
+}


### PR DESCRIPTION
added patch that allows marking powers/spells so their effects won't get removed on location change and marked Soul Empower with this new marker.