### PR TITLE
Improve somatic and material components

### DIFF
--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CustomSpells/RulesetCharacterPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CustomSpells/RulesetCharacterPatcher.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.CustomFeatures.CustomSpells
+{
+    internal static class RulesetCharacterPatcher
+    {
+        // Allows valid Somatic component if specific material component is held in main hand or off hand slots
+        [HarmonyPatch(typeof(RulesetCharacter), "IsComponentSomaticValid")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+        internal static class RulesetCharacter_IsComponentSomaticValid
+        {
+            internal static void Postfix(RulesetCharacter __instance, ref bool __result,
+                SpellDefinition spellDefinition, ref string failure)
+            {
+                if (!__result && spellDefinition.MaterialComponentType ==
+                    RuleDefinitions.MaterialComponentType.Specific)
+                {
+                    var materialTag = spellDefinition.SpecificMaterialComponentTag;
+                    var inventorySlotsByName = __instance.CharacterInventory.InventorySlotsByName;
+                    var mainHand = inventorySlotsByName[EquipmentDefinitions.SlotTypeMainHand].EquipedItem;
+                    var offHand = inventorySlotsByName[EquipmentDefinitions.SlotTypeOffHand].EquipedItem;
+
+                    var tagsMap = new Dictionary<string, TagsDefinitions.Criticity>();
+                    if (mainHand != null)
+                    {
+                        mainHand.FillTags(tagsMap, __instance, true);
+                    }
+
+                    if (offHand != null)
+                    {
+                        offHand.FillTags(tagsMap, __instance, true);
+                    }
+
+                    if (tagsMap.Keys.Contains(materialTag))
+                    {
+                        __result = true;
+                        failure = string.Empty;
+                    }
+                }
+            }
+        }
+
+        // Allows spells to satisfy specific material components by actual active tags on an item that are not directly defined in ItemDefinition (like "Melee")
+        [HarmonyPatch(typeof(RulesetCharacter), "IsComponentMaterialValid")]
+        [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+        internal static class RulesetCharacter_IsComponentMaterialValid
+        {
+            internal static void Postfix(RulesetCharacter __instance, ref bool __result,
+                SpellDefinition spellDefinition, ref string failure)
+            {
+                if (!__result && spellDefinition.MaterialComponentType ==
+                    RuleDefinitions.MaterialComponentType.Specific)
+                {
+                    var materialTag = spellDefinition.SpecificMaterialComponentTag;
+                    var requiredCost = spellDefinition.SpecificMaterialComponentCostGp;
+
+                    List<RulesetItem> items = new();
+                    __instance.CharacterInventory.EnumerateAllItems(items);
+                    var tagsMap = new Dictionary<string, TagsDefinitions.Criticity>();
+                    foreach (RulesetItem rulesetItem in items)
+                    {
+                        tagsMap.Clear();
+                        rulesetItem.FillTags(tagsMap, __instance, true);
+                        var itemItemDefinition = rulesetItem.ItemDefinition;
+                        int costInGold = EquipmentDefinitions.GetApproximateCostInGold(itemItemDefinition.Costs);
+                        if (tagsMap.Keys.Contains(materialTag) && costInGold >= requiredCost)
+                        {
+                            __result = true;
+                            failure = String.Empty;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Spells/EWSpells.cs
+++ b/SolastaCommunityExpansion/Spells/EWSpells.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using SolastaCommunityExpansion.Api.AdditionalExtensions;
+﻿using SolastaCommunityExpansion.Api.AdditionalExtensions;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Builders.Features;
 using SolastaCommunityExpansion.CustomDefinitions;
@@ -59,6 +58,8 @@ namespace SolastaCommunityExpansion.Spells
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation)
                 .SetSomaticComponent(true)
                 .SetVerboseComponent(false)
+                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Specific)
+                .SetSpecificMaterialComponent(TagsDefinitions.WeaponTagMelee, 0, false)
                 .SetCustomSubFeatures(
                     PerformAttackAfterMagicEffectUse.MeleeAttack,
                     CustomSpellEffectLevel.ByCasterLevel
@@ -189,6 +190,8 @@ namespace SolastaCommunityExpansion.Spells
                 .SetSchoolOfMagic(DatabaseHelper.SchoolOfMagicDefinitions.SchoolEvocation)
                 .SetSomaticComponent(true)
                 .SetVerboseComponent(false)
+                .SetMaterialComponent(RuleDefinitions.MaterialComponentType.Specific)
+                .SetSpecificMaterialComponent(TagsDefinitions.WeaponTagMelee, 0, false)
                 .SetCustomSubFeatures(
                     PerformAttackAfterMagicEffectUse.MeleeAttack,
                     CustomSpellEffectLevel.ByCasterLevel,

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -109,7 +109,7 @@ Condition/&EvilEyeTitle	Evil Eye
 Condition/&EWResonatingStrikeDamageDescription Starting from level 5 attack triggered by this cantrip deals additional 1d8 thunder damage. The damage increases by 1d8 at 11th and 17th levels.
 Condition/&EWResonatingStrikeDamageTitle	Resonance
 Condition/&EWSunlightBladeDamageDescription Starting from level 5 attack triggered by this cantrip deals additional 1d8 radiant damage. The damage increases by 1d8 at 11th and 17th levels.
-Condition/&EWSunlightBladeDamageTitle	Sunlight Blade's burn
+Condition/&EWSunlightBladeDamageTitle	Sunlit Blade's burn
 Condition/&FrenziedDescription	This creature is frenzied and will attack the closest creature
 Condition/&FrenziedTitle	Frenzied
 Condition/&HalfLifeConditionDescription	You take necrotic energy into yourself and hang between life and death and are temporarily possessed by your own ghost, gaining flying, and the same condition immunities and damage resistenances as other ghosts
@@ -1122,8 +1122,8 @@ Feedback/&AdditionalDamageResonatingStrikeFormat	Resonating Strike!
 Feedback/&AdditionalDamageResonatingStrikeLine	{0} resonates {1}! (+{2})
 Feedback/&AdditionalDamageSoulEmpoweredFormat	Soul Empowered!
 Feedback/&AdditionalDamageSoulEmpoweredLine	Soul Empowered does additional damage!
-Feedback/&AdditionalDamageSunlightBladeFormat	Sunlight Blade!
-Feedback/&AdditionalDamageSunlightBladeLine	{0} burns {1} with Sunlight Blade! (+{2})
+Feedback/&AdditionalDamageSunlightBladeFormat	Sunlit Blade!
+Feedback/&AdditionalDamageSunlightBladeLine	{0} burns {1} with Sunlit Blade! (+{2})
 Feedback/&AdditionalDamageUpgradedConstructFormat	Upgraded Damage
 Feedback/&AdditionalDamageUpgradedConstructLine	The upgraded construct deals 1D8 more damage per hit
 Feedback/&AncientForestHerbalBrewDamageAffinityAcidResistancePowerUsedWhileTravellingFormat	{0} creates {1}
@@ -1434,7 +1434,7 @@ Spell/&EldritchOrbTitle	Eldritch Orb
 Spell/&EWResonatingStrikeDescription	Select one creature within melee range of you and a different creature that you can see within 5 feet of main target. You make a melee attack with current weapon against first creature. On a hit, the target suffers the weapon attack's normal effects, and resonating sound leaps to second target, dealing thunder damage equal to your spellcasting ability modifier.\nAt 5th level, the melee attack deals extra 1d8 thunder damage to the target on a hit, and the thunder damage to the second creature increases to 1d8 + your spellcasting ability modifier. Both damage rolls increase by 1d8 at 11th and 17th levels.
 Spell/&EWResonatingStrikeTitle	Resonating Strike
 Spell/&EWSunlightBladeDescription	Make a melee attack with a weapon. On a hit, the target suffers the attack's normal effects, and is enveloped in glowing radiant energy, shedding dim light for the turn. Next attack against this creature while it is highlighted is done with advantage.\nAt 5th level, the melee attack deals an extra 1d8 radiant damage to the target. The damage increases by another 1d8 at 11th level and 17th level.
-Spell/&EWSunlightBladeTitle	Sunlight Blade
+Spell/&EWSunlightBladeTitle	Sunlit Blade
 Spell/&FindFamiliarDescription	You gain the service of a familiar
 Spell/&FindFamiliarImpDescription	Summons your familiar in the form of an imp
 Spell/&FindFamiliarImpTitle	Find Familiar (Imp)


### PR DESCRIPTION
 - added patch to allow valid Somatic component if specific material component is held in main hand or off hand slots 
 - added patch to allow spells to satisfy specific material components by actual active tags on an item that are not directly defined in `ItemDefinition` (like `Melee`)
 - made `Sunlight Blade` and `Resonating Strike` require `Melee` as their material component