### PR TITLE
Resonating strike fixes

### DIFF
--- a/SolastaCommunityExpansion/Spells/EWSpells.cs
+++ b/SolastaCommunityExpansion/Spells/EWSpells.cs
@@ -292,7 +292,7 @@ namespace SolastaCommunityExpansion.Spells
             }
 
             if (attackOutcome != RuleDefinitions.RollOutcome.Success 
-                && attackOutcome == RuleDefinitions.RollOutcome.CriticalSuccess)
+                && attackOutcome != RuleDefinitions.RollOutcome.CriticalSuccess)
             {
                 return null;
             }

--- a/SolastaCommunityExpansion/Spells/EWSpells.cs
+++ b/SolastaCommunityExpansion/Spells/EWSpells.cs
@@ -323,6 +323,8 @@ namespace SolastaCommunityExpansion.Spells
 
                 effectSpell.ApplyEffectOnCharacter(rulesetTarget, true, targets[i].LocationPosition);
             }
+            
+            effectSpell.Terminate(true);
 
             return null;
         }


### PR DESCRIPTION
fixed Resonating Strike skpping secondary target only on crits instead of misses and crit misses
fixed broken sves madeafter using Resonating Strike - it wasn't terminating effect properly