### PR TITLE
Fix warcaster opportunity

### DIFF
--- a/SolastaCommunityExpansion/Api/AdditionalExtensions/CharacterReactionSubitemExtension.cs
+++ b/SolastaCommunityExpansion/Api/AdditionalExtensions/CharacterReactionSubitemExtension.cs
@@ -49,7 +49,7 @@ namespace SolastaCommunityExpansion.Api.AdditionalExtensions
             instance.SubitemSelected = subitemSelected;
 
             var rectTransform = toggle.GetComponent<RectTransform>();
-            rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 300);
+            rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 250);
 
             // Hide all slots
             var slotStatusTable = instance.GetField<RectTransform>("slotStatusTable");

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/CharacterReactionItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/CharacterReactionItemPatcher.cs
@@ -6,6 +6,7 @@ using System.Reflection.Emit;
 using HarmonyLib;
 using SolastaCommunityExpansion.Api.AdditionalExtensions;
 using SolastaCommunityExpansion.CustomUI;
+using UnityEngine;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures.CustomReactions
 {
@@ -33,6 +34,16 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.CustomReactions
                 }
 
                 return codes.AsEnumerable();
+            }
+
+            internal static void Postfix(CharacterReactionItem __instance)
+            {
+                var size = __instance.ReactionRequest is ReactionRequestWarcaster
+                    ? 400
+                    : 290;
+                
+                __instance.GetComponent<RectTransform>()
+                    .SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, size);
             }
 
             private static void CustomBind(CharacterReactionSubitem instance,

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/CharacterReactionItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/CharacterReactionItemPatcher.cs
@@ -42,7 +42,6 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.CustomReactions
                 bool interactable,
                 CharacterReactionSubitem.SubitemSelectedHandler subitemSelected, ReactionRequest reactionRequest)
             {
-                Main.Log($"CustomBind ", true);
                 if (reactionRequest is ReactionRequestWarcaster warcasterRequest)
                 {
                     instance.BindWarcaster(warcasterRequest, slotLevel, interactable, subitemSelected);

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/GameLocationActionManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/GameLocationActionManagerPatcher.cs
@@ -1,7 +1,5 @@
-﻿using System.Linq;
-using HarmonyLib;
+﻿using HarmonyLib;
 using SolastaCommunityExpansion.CustomUI;
-using SolastaModApi.Extensions;
 using SolastaModApi.Infrastructure;
 
 namespace SolastaCommunityExpansion.Patches.CustomFeatures.CustomReactions
@@ -13,24 +11,9 @@ namespace SolastaCommunityExpansion.Patches.CustomFeatures.CustomReactions
         {
             internal static bool Prefix(GameLocationActionManager __instance, CharacterActionParams reactionParams)
             {
-                var rulesetCharacter = reactionParams?.ActingCharacter?.RulesetCharacter;
+                __instance.InvokeMethod("AddInterruptRequest", new ReactionRequestWarcaster(reactionParams));
 
-                // should not trigger if a wildshape form
-                if (rulesetCharacter is not RulesetCharacterHero rulesetCharacterHero)
-                {
-                    return true;
-                }
-
-                var affinities = rulesetCharacterHero.GetFeaturesByType<FeatureDefinitionMagicAffinity>();
-
-                if (affinities != null && affinities.Any(a => a.Name == "MagicAffinityWarCasterFeat"))
-                {
-                    __instance.InvokeMethod("AddInterruptRequest", new ReactionRequestWarcaster(reactionParams));
-
-                    return false;
-                }
-
-                return true;
+                return false;
             }
         }
     }

--- a/SolastaCommunityExpansion/Translations-en.txt
+++ b/SolastaCommunityExpansion/Translations-en.txt
@@ -1331,8 +1331,8 @@ Reaction/&SubitemSelectSlotLevelTitle	Slot Level
 Reaction/&SubitemSelectWarcasterTitle	Select action
 Reaction/&WarcasterAttackDescription	Attack target
 Reaction/&WarcasterAttackTitle	Attack
-Reaction/&WarcasterReactionDescription	{1} is leaving a threatened area. {0} can attack or cast cantrip in responce.
-Reaction/&WarcasterReactionTitle	Warcaster's Opportunity
+Reaction/&WarcasterReactionDescription	{0} is leaving an area threatened by one or more characters.
+Reaction/&WarcasterReactionTitle	Attack of Opportunity
 Requirement/&FeatureSelectionRequireCharacterLevel	Level {0}
 Requirement/&FeatureSelectionRequireClassLevel	Level {0} of {1}
 Requirement/&WarlockMissingEldritchBlast	Eldritch Blast cantrip


### PR DESCRIPTION
When character triggers AoO from several heros at once regular and warcaster requests got mixed and there were wierd bugs in passing data. Made all attacks of opportunity use warcaster reaction request to fix that issue. Also resized character items on warcaster requests, so they won't overlap.