### PR TITLE
Fixed summons disappearing on world travel

### DIFF
--- a/SolastaCommunityExpansion/Patches/Bugfix/GameLocationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Bugfix/GameLocationManagerPatcher.cs
@@ -13,6 +13,7 @@ namespace SolastaCommunityExpansion.Patches.Bugfix
     [HarmonyPatch(typeof(GameLocationManager), "StopCharacterEffectsIfRelevant")]
     internal static class GameLocationManager_StopCharacterEffectsIfRelevant
     {
+#if false //Disabling force unsummon part since it looks like it is needed
         internal static void Prefix(GameLocationManager __instance, bool willEnterChainedLocation)
         {
             if (willEnterChainedLocation) { return; }
@@ -38,6 +39,7 @@ namespace SolastaCommunityExpansion.Patches.Bugfix
                 }
             }
         }
+#endif
 
         internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {


### PR DESCRIPTION
Disabling force unsummon part of the patch since it looks like it is needed - with preservation of `summoned` condition from Transpiler patch everything seems to work fine