### PR TITLE
Power tooltip fixes

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameUi/Tooltip/RecoveredFeatureItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Tooltip/RecoveredFeatureItemPatcher.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.GameUi.Tooltip;
+
+internal static class RecoveredFeatureItemPatcher
+{
+    [HarmonyPatch(typeof(RecoveredFeatureItem), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class UsablePowerBox_Bind
+    {
+        internal static void Postfix(RecoveredFeatureItem __instance, RulesetCharacterHero character)
+        {
+            __instance.GuiTooltip.Context = character;
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/Tooltip/TooltipFeaturePowerParametersPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Tooltip/TooltipFeaturePowerParametersPatcher.cs
@@ -1,0 +1,54 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaCommunityExpansion.Models;
+using SolastaModApi.Infrastructure;
+
+namespace SolastaCommunityExpansion.Patches.GameUi.Tooltip;
+
+internal static class TooltipFeaturePowerParametersPatcher
+{
+    [HarmonyPatch(typeof(TooltipFeaturePowerParameters), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class TooltipFeaturePowerParameters_Bind
+    {
+        internal static void Postfix(TooltipFeaturePowerParameters __instance, ITooltip tooltip)
+        {
+            if (tooltip.DataProvider == null || tooltip.DataProvider is not GuiPowerDefinition guiPowerDefinition)
+            {
+                return;
+            }
+
+            if (tooltip.Context == null || tooltip.Context is not RulesetCharacter character)
+            {
+                return;
+            }
+
+            var power = guiPowerDefinition.PowerDefinition;
+            var usesLabel = __instance.GetField<GuiLabel>("usesLabel");
+            usesLabel.Text = FormatUses(power, character, usesLabel.Text);
+        }
+
+        private static string FormatUses(FeatureDefinitionPower power, RulesetCharacter character, string def)
+        {
+            if (power.UsesDetermination != RuleDefinitions.UsesDetermination.Fixed)
+            {
+                return def;
+            }
+
+            if (power.RechargeRate == RuleDefinitions.RechargeRate.AtWill)
+            {
+                return def;
+            }
+
+            if (power.CostPerUse == 0)
+            {
+                return def;
+            }
+
+            var usablePower = UsablePowersProvider.Get(power, character);
+            var maxUses = CustomFeaturesContext.GetMaxUsesForPool(usablePower, character);
+            var remainingUses = character.GetRemainingUsesOfPower(usablePower);
+            return $"{remainingUses}/{maxUses}";
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/GameUi/Tooltip/UsablePowerBoxPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameUi/Tooltip/UsablePowerBoxPatcher.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+
+namespace SolastaCommunityExpansion.Patches.GameUi.Tooltip;
+
+internal static class UsablePowerBoxPatcher
+{
+    [HarmonyPatch(typeof(UsablePowerBox), "Bind")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class UsablePowerBox_Bind
+    {
+        internal static void Postfix(UsablePowerBox __instance)
+        {
+            var panel = __instance.GetComponentInParent<CharacterControlPanelExploration>();
+            if (panel == null)
+            {
+                return;
+            }
+
+            __instance.GuiTooltip.Context = panel.GuiCharacter?.RulesetCharacter;
+        }
+    }
+}


### PR DESCRIPTION
added patches to make power tooltips for powers in power use menu and rest recovered features have proper uses count - accounting for shared pool and bonuses from power pool modifiers.