### PR TITLE
Fix toggled powers

### DIFF
--- a/SolastaCommunityExpansion/CustomDefinitions/ModifyAttackModeForWeapon.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/ModifyAttackModeForWeapon.cs
@@ -157,3 +157,17 @@ public class AddEffectToWeaponAttack : ModifyAttackModeForWeaponBase
         attackMode.EffectDescription.AddEffectForms(effect);
     }
 }
+
+public class BumpWeaponAttackRangeToMax : ModifyAttackModeForWeaponBase
+{
+    public BumpWeaponAttackRangeToMax(IsWeaponValidHandler isWeaponValid, params CharacterValidator[] validators)
+        : base(isWeaponValid, validators)
+    {
+    }
+
+    protected override void TryModifyAttackMode(RulesetCharacter character, RulesetAttackMode attackMode,
+        RulesetItem weapon)
+    {
+        attackMode.closeRange = attackMode.maxRange;
+    }
+}

--- a/SolastaCommunityExpansion/Feats/AcehighFeats.cs
+++ b/SolastaCommunityExpansion/Feats/AcehighFeats.cs
@@ -2,6 +2,7 @@
 using SolastaCommunityExpansion.Api.AdditionalExtensions;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.Builders.Features;
+using SolastaCommunityExpansion.CustomDefinitions;
 using SolastaCommunityExpansion.CustomInterfaces;
 using SolastaCommunityExpansion.CustomUI;
 using SolastaCommunityExpansion.Models;
@@ -36,9 +37,8 @@ internal static class AcehighFeats
             Definition.GuiPresentation.Title = "Feature/&DeadeyeTitle";
             Definition.GuiPresentation.Description = "Feature/&DeadeyeDescription";
 
-            Definition.SetIgnoreRangeAdvantage(true);
             Definition.SetIgnoreCover(true);
-            Definition.SetSituationalContext(RuleDefinitions.SituationalContext.AttackingWithBow);
+            Definition.SetCustomSubFeatures(new BumpWeaponAttackRangeToMax(WeaponValidators.AlwaysValid));
         }
 
         private static FeatureDefinition CreateAndAddToDB(string name, string guid)

--- a/SolastaCommunityExpansion/Resources/Translations/Translations-en.txt
+++ b/SolastaCommunityExpansion/Resources/Translations/Translations-en.txt
@@ -908,7 +908,7 @@ Feature/&CounterStrikePowerDescription	Spend a gambit die and Counter Strike the
 Feature/&CounterStrikePowerTitle	Counter Strike
 Feature/&DamageAffinityGiftoftheProtectorsRelentlessEnduranceDescription	When you are reduced to 0 HP but not killed, you can drop to 1 HP instead.
 Feature/&DamageAffinityGiftoftheProtectorsRelentlessEnduranceTitle	Relentless Endurance
-Feature/&DeadeyeDescription	Attacking at long range doesn't impose disadvantage on your ranged weapon attack rolls. Your ranged weapons ignore half cover and three-quarters cover. You can choose to take a -5 Bonus penalty to your to hit in order to do a +10 proficiency bonus damage.
+Feature/&DeadeyeDescription	Attacking at long range doesn't impose disadvantage on your ranged weapon attack rolls. Your ranged weapons ignore half cover and three-quarters cover. You can choose to take a -5 Bonus penalty to your to hit in order to do a +10 bonus damage.
 Feature/&DeadeyeTitle	Deadeye
 Feature/&DevilsSightDescription	You can see normally in Darkness, both magical and non-magical, to a distance of 120 feet.
 Feature/&DevilsSightTitle	Devil's Sight
@@ -1076,7 +1076,7 @@ Feature/&OpportunistDebilitatingStrikeTitle	Debilitating Strike
 Feature/&OpportunistQuickStrikeDescription	You have advantage when attack an enemies whose initiative is lower than yours. In addition, you also have advantage when perform an attack of opportunity.
 Feature/&OpportunistQuickStrikeTitle	Quick Strike
 Feature/&OtherworldlyLeapTitle	Otherworldly Leap
-Feature/&PowerAttackDescription	Take a -3 to hit penalty to your attack for the rest of the turn to do 3 + Proficiency Bonus extra damage when you land your strikes with melee weapons.
+Feature/&PowerAttackDescription	Take a -3 to hit penalty to your attack to do 3 + Proficiency Bonus extra damage when you land your strikes with melee weapons.
 Feature/&PowerAttackTitle	Power attack
 Feature/&PowerPaladinAuraOfCourage18Description	Grant a saving throw bonus to allies within 30ft.
 Feature/&PowerPaladinAuraOfCourage18Title	Improved Aura of Courage
@@ -2037,14 +2037,14 @@ Subclass/&WitchSubclassPathDescription	Your knowledge of magic has culminated in
 Subclass/&WitchSubclassPathTitle	Witch Covens
 ToolTip/&CheckBoxDefaultPartyTitle	Check this box to set your default party when starting new advendures or testing custom locations. You can select up to {0} heroes in a first-in / first-out basis
 Tooltip/&CustomPortraitPoolClassMonkKiPool	You can harness the mystic energy of ki. Your access to this energy is represented by a number of ki points. Maximum amount is equal to your monk level. All spent points are regained on short or long rest. You can spend these points to fuel various ki features
-Tooltip/&DeadeyeConcentration	Disable Deadeye.\nEffect will last until start of your next turn
+Tooltip/&DeadeyeConcentration	Disable Deadeye.
 Tooltip/&FeatPrerequisiteDoesNotHaveFightingStyle	Doesn't know {0}
 Tooltip/&FeatPrerequisiteHasStealthAttack	Has stealth attack
 Tooltip/&FeatPrerequisiteIsNotBarbarian	Isn't a Barbarian
 Tooltip/&FeatPrerequisiteIsNotFighter	Isn't a Fighter
 Tooltip/&FeatPrerequisiteIsNotRogue	Isn't a Rogue
 Tooltip/&FeatPrerequisiteLevelFormat	Min Character Level {0}
-Tooltip/&PowerAttackConcentration	Disable Power Attack.\nEffect will last until start of your next turn
+Tooltip/&PowerAttackConcentration	Disable Power Attack.
 Tooltip/&Tag9000Title	Custom Effect
 Tooltip/&TagCommunityExpansionTitle	Community Expansion
 Tooltip/&TagMaledictionTitle	Malediction


### PR DESCRIPTION
Made Power Attack and Deadeye use silent power to remove their effects, instead of manually removing conditions. This should fix network desync.
Fixed deadeye removing all advantage/disadvantage from ranged attacks instead of removing disadvantage on long range shots.
Fixes #1340 