### PR TITLE
Reckless fix

### DIFF
--- a/SolastaCommunityExpansion/Api/AdditionalExtensions/RulesetCharacterExension.cs
+++ b/SolastaCommunityExpansion/Api/AdditionalExtensions/RulesetCharacterExension.cs
@@ -48,4 +48,23 @@ internal static class RulesetCharacterExension
         return instance.GetSubFeaturesByType<IAttackModificationProvider>()
             .Any(p => p.CanAddAbilityBonusToSecondary);
     }
+
+    public static RulesetItem GetItemInSlot(this RulesetCharacter instance, string slot)
+    {
+        if (instance == null 
+            || instance.CharacterInventory == null 
+            || instance.CharacterInventory.InventorySlotsByName == null
+           )
+        {
+            return null;
+        }
+
+        var inventorySlot = instance.CharacterInventory.InventorySlotsByName[slot];
+        if (inventorySlot == null)
+        {
+            return null;
+        }
+
+        return inventorySlot.EquipedItem;
+    }
 }

--- a/SolastaCommunityExpansion/CustomDefinitions/ExtendedSituationalContext.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/ExtendedSituationalContext.cs
@@ -1,0 +1,23 @@
+﻿using SolastaCommunityExpansion.Models;
+
+namespace SolastaCommunityExpansion.CustomDefinitions;
+
+public enum ExtendedSituationalContext
+{
+    MainWeaponIsMelee = 1000,
+}
+
+public static class CustomSituationalContext
+{
+    public static bool IsContextValid(RulesetImplementationDefinitions.SituationalContextParams contextParams, bool def)
+    {
+        var context = contextParams.situationalContext;
+        switch ((ExtendedSituationalContext) context)
+        {
+            case ExtendedSituationalContext.MainWeaponIsMelee:
+                return CharacterValidators.MainHandIsMeleeWeapon(contextParams.source);
+        }
+
+        return def;
+    }
+}

--- a/SolastaCommunityExpansion/Feats/AcehighFeats.cs
+++ b/SolastaCommunityExpansion/Feats/AcehighFeats.cs
@@ -21,7 +21,6 @@ internal static class AcehighFeats
     {
         feats.Add(DeadeyeFeatBuilder.DeadeyeFeat);
         feats.Add(BuildPowerAttackFeat());
-        feats.Add(RecklessFuryFeatBuilder.RecklessFuryFeat);
     }
 
     private static FeatDefinition BuildPowerAttackFeat()
@@ -400,6 +399,7 @@ internal static class AcehighFeats
         }
     }
 
+    // Leaving this to not break existing characters
     private sealed class RecklessFuryFeatBuilder : FeatDefinitionBuilder
     {
         private const string RecklessFuryFeatName = "RecklessFuryFeat";

--- a/SolastaCommunityExpansion/Feats/EWFeats.cs
+++ b/SolastaCommunityExpansion/Feats/EWFeats.cs
@@ -14,6 +14,7 @@ public static class EWFeats
     public const string SentinelFeat = "FeatSentinel";
     public const string PolearmExpertFeat = "FeatPolearmExpert";
     public const string RangedExpertFeat = "FeatRangedExpert";
+    public const string RecklessAttackFeat = "FeatRecklessAttack";
     private static readonly Guid GUID = new("B4ED480F-2D06-4EB1-8732-9A721D80DD1A");
 
     public static void CreateFeats(List<FeatDefinition> feats)
@@ -21,6 +22,7 @@ public static class EWFeats
         feats.Add(BuildSentinel());
         feats.Add(BuildPolearmExpert());
         feats.Add(BuildRangedExpert());
+        feats.Add(BuildRecklessAttack());
     }
 
     private static FeatDefinition BuildSentinel()
@@ -110,6 +112,16 @@ public static class EWFeats
                         CharacterValidators.HasAttacked)
                 )
                 .AddToDB())
+            .AddToDB();
+    }
+
+    private static FeatDefinition BuildRecklessAttack()
+    {
+        return FeatDefinitionWithPrerequisitesBuilder
+            .Create(RecklessAttackFeat, GUID)
+            .SetGuiPresentation("RecklessAttack", Category.Action)
+            .SetFeatures(FeatureDefinitionActionAffinitys.ActionAffinityBarbarianRecklessAttack)
+            .SetValidators(FeatsValidations.ValidateNotClass(CharacterClassDefinitions.Barbarian))
             .AddToDB();
     }
 

--- a/SolastaCommunityExpansion/Models/HouseFeatureContext.cs
+++ b/SolastaCommunityExpansion/Models/HouseFeatureContext.cs
@@ -11,12 +11,13 @@ public static class HouseFeatureContext
     {
         FixDivineSmiteRestrictions();
         FixMountaineerBonusShoveRestrictions();
+        FixRecklessAttckForReachWeapons();
     }
 
     /**
-         * Makes Divine Smite trigger only from melee attacks.
-         * This wasn't relevant until we changed how SpendSpellSlot trigger works.
-         */
+     * Makes Divine Smite trigger only from melee attacks.
+     * This wasn't relevant until we changed how SpendSpellSlot trigger works.
+     */
     private static void FixDivineSmiteRestrictions()
     {
         DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamagePaladinDivineSmite
@@ -25,12 +26,22 @@ public static class HouseFeatureContext
     }
 
     /**
-         * Makes Mountaineer's `Shield Push` bonus shove work only with shield equipped.
-         * This wasn't relevant until we removed forced shield check in the `GameLocationCharacter.GetActionStatus`.
-         */
+     * Makes Mountaineer's `Shield Push` bonus shove work only with shield equipped.
+     * This wasn't relevant until we removed forced shield check in the `GameLocationCharacter.GetActionStatus`.
+     */
     private static void FixMountaineerBonusShoveRestrictions()
     {
         DatabaseHelper.FeatureDefinitionActionAffinitys.ActionAffinityMountaineerShieldCharge
             .SetCustomSubFeatures(new FeatureApplicationValidator(CharacterValidators.HasShield));
+    }
+
+    /**
+     * Makes `Reckless` context check if main hand weapon is melee, instead of if character is next to target.
+     * Required for it to work on reach weapons.
+     */
+    private static void FixRecklessAttckForReachWeapons()
+    {
+        DatabaseHelper.FeatureDefinitionCombatAffinitys.CombatAffinityReckless
+            .situationalContext = (RuleDefinitions.SituationalContext) ExtendedSituationalContext.MainWeaponIsMelee;
     }
 }

--- a/SolastaCommunityExpansion/Models/_CharacterValidator.cs
+++ b/SolastaCommunityExpansion/Models/_CharacterValidator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using SolastaCommunityExpansion.Api.AdditionalExtensions;
 
 namespace SolastaCommunityExpansion.Models;
 
@@ -21,6 +22,9 @@ public static class CharacterValidators
         return WeaponValidators.IsPolearm(slotsByName[EquipmentDefinitions.SlotTypeMainHand].EquipedItem)
                || WeaponValidators.IsPolearm(slotsByName[EquipmentDefinitions.SlotTypeOffHand].EquipedItem);
     };
+
+    public static readonly CharacterValidator MainHandIsMeleeWeapon = character =>
+        WeaponValidators.IsMelee(character.GetItemInSlot(EquipmentDefinitions.SlotTypeMainHand));
 
     public static readonly CharacterValidator FullyUnarmed = character =>
     {

--- a/SolastaCommunityExpansion/Models/_WeaponValidator.cs
+++ b/SolastaCommunityExpansion/Models/_WeaponValidator.cs
@@ -29,6 +29,11 @@ public static class WeaponValidators
                && CustomWeaponsContext.PolearmWeaponTypes.Contains(weapon.WeaponDescription?.WeaponType);
     }
 
+    public static bool IsMelee(RulesetItem weapon)
+    {
+        return !HasAnyWeaponTag(weapon, TagsDefinitions.WeaponTagRange, TagsDefinitions.WeaponTagThrown);
+    }
+
     public static bool IsRanged(RulesetItem weapon)
     {
         return HasAnyWeaponTag(weapon, TagsDefinitions.WeaponTagRange, TagsDefinitions.WeaponTagThrown);

--- a/SolastaCommunityExpansion/Patches/Insertion/RulesetImplementationManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Insertion/RulesetImplementationManagerPatcher.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaCommunityExpansion.CustomDefinitions;
+
+namespace SolastaCommunityExpansion.Patches.Insertion;
+
+internal static class RulesetImplementationManagerPatcher
+{
+    [HarmonyPatch(typeof(RulesetImplementationManagerLocation), "IsSituationalContextValid")]
+    [HarmonyPatch(new[] {typeof(RulesetImplementationDefinitions.SituationalContextParams)})]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class IsSituationalContextValid
+    {
+        internal static void Postfix(RulesetImplementationManagerLocation __instance, ref bool __result,
+            RulesetImplementationDefinitions.SituationalContextParams contextParams)
+        {
+            __result = CustomSituationalContext.IsContextValid(contextParams, __result);
+        }
+    }
+}


### PR DESCRIPTION
- fixed reckless attack not working for reach weapons
- replaced `Reckless Fury` feat with `Reckless Attack` that directly uses Barbarian's feature. Old feat is still present to not break characters, but is hidden.