### PR TITLE
Change IncreaseSenseNormalVision to slider

### DIFF
--- a/SolastaCommunityExpansion/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Displays/RulesDisplay.cs
@@ -9,6 +9,7 @@ internal static class RulesDisplay
     internal static void DisplayRules()
     {
         bool toggle;
+        int intValue;
 
         UI.Label("");
         UI.Label(Gui.Localize("ModUi/&SRD"));
@@ -118,10 +119,12 @@ internal static class RulesDisplay
 
         UI.Label("");
 
-        toggle = Main.Settings.IncreaseSenseNormalVision;
-        if (UI.Toggle(Gui.Localize("ModUi/&IncreaseSenseNormalVision"), ref toggle, UI.AutoWidth()))
+        intValue = Main.Settings.IncreaseSenseNormalVision;
+        if (UI.Slider(Gui.Localize("ModUi/&IncreaseSenseNormalVision"), ref intValue,
+                HouseFeatureContext.DEFAULT_VISION_RANGE, HouseFeatureContext.MAX_VISION_RANGE,
+                HouseFeatureContext.DEFAULT_VISION_RANGE, "", UI.AutoWidth()))
         {
-            Main.Settings.IncreaseSenseNormalVision = toggle;
+            Main.Settings.IncreaseSenseNormalVision = intValue;
         }
 
         UI.Label("");

--- a/SolastaCommunityExpansion/Models/HouseFeatureContext.cs
+++ b/SolastaCommunityExpansion/Models/HouseFeatureContext.cs
@@ -7,6 +7,9 @@ namespace SolastaCommunityExpansion.Models;
 
 public static class HouseFeatureContext
 {
+    internal const int DEFAULT_VISION_RANGE = 16;
+    internal const int MAX_VISION_RANGE = 120;
+
     public static void LateLoad()
     {
         FixDivineSmiteRestrictions();

--- a/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
+++ b/SolastaCommunityExpansion/Models/InitialChoicesContext.cs
@@ -87,9 +87,9 @@ internal static class InitialChoicesContext
             }
         }
 
-        if (Main.Settings.IncreaseSenseNormalVision)
+        if (Main.Settings.IncreaseSenseNormalVision > HouseFeatureContext.DEFAULT_VISION_RANGE)
         {
-            SenseNormalVision.SetSenseRange(120);
+            SenseNormalVision.SetSenseRange(Main.Settings.IncreaseSenseNormalVision);
         }
     }
 

--- a/SolastaCommunityExpansion/Resources/Translations/Modui-en.txt
+++ b/SolastaCommunityExpansion/Resources/Translations/Modui-en.txt
@@ -101,7 +101,7 @@ ModUi/&HideExitAndTeleporterGizmosIfNotDiscovered	Hide exits and teleporters vis
 ModUi/&HideMonsterHitPoints	Display Monsters's health in steps of 25% / 50% / 75% / 100% instead of exact hit points
 ModUi/&HiderArmor	Hide Armor
 ModUi/&House	<color=yellow>House:</color>
-ModUi/&IncreaseSenseNormalVision	Increase <color=orange>Sense Normal Vision</color> range to enable long range attacks <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
+ModUi/&IncreaseSenseNormalVision	<color=white>Increase <color=orange>Sense Normal Vision</color> range to enable long range attacks (40 is ideal to avoid enemies joining from too far away) </color><b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&InitialChoices	<color=yellow>Initial choices:</color>
 ModUi/&Interface	Interface
 ModUi/&InventoryAndItems	<color=yellow>Inventory and items:</color>

--- a/SolastaCommunityExpansion/Utils/Settings.cs
+++ b/SolastaCommunityExpansion/Utils/Settings.cs
@@ -156,7 +156,7 @@ public class Settings : UnityModManager.ModSettings
     public bool AllowDruidToWearMetalArmor { get; set; }
     public bool DisableAutoEquip { get; set; }
     public bool MakeAllMagicStaveArcaneFoci { get; set; }
-    public bool IncreaseSenseNormalVision { get; set; }
+    public int IncreaseSenseNormalVision { get; set; } = HouseFeatureContext.DEFAULT_VISION_RANGE;
 
     public bool QuickCastLightCantripOnWornItemsFirst { get; set; }
 


### PR DESCRIPTION
Changing the `Increase SenseNormalVision` to a slider is a neat solution to allow customizable ranges for the players that want to take the risk of enemies joining battle to be able to fully utilize their max range, while also allowing players that just want to up their vision to 24 avoid taking that same risk.
I've added the recommendation of setting it to 40, because, empirically, it was the range that allowed most of my characters to fully utilize their range, without having much trouble of unwanted enemies joining combat

Closes #1367 