### PR TITLE
Made Divine Smite use correct number of dice when spending slot level 5+

### DIFF
--- a/SolastaCommunityExpansion/Models/HouseFeatureContext.cs
+++ b/SolastaCommunityExpansion/Models/HouseFeatureContext.cs
@@ -1,5 +1,6 @@
 ﻿using SolastaCommunityExpansion.Api;
 using SolastaCommunityExpansion.Api.Extensions;
+using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomDefinitions;
 
 namespace SolastaCommunityExpansion.Models;
@@ -12,6 +13,7 @@ public static class HouseFeatureContext
     public static void LateLoad()
     {
         FixDivineSmiteRestrictions();
+        FixDivineSmiteDiceNumberWhenUsingHighLevelSlots();
         FixMountaineerBonusShoveRestrictions();
         FixRecklessAttckForReachWeapons();
     }
@@ -25,6 +27,16 @@ public static class HouseFeatureContext
         DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamagePaladinDivineSmite.attackModeOnly = true;
         DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamagePaladinDivineSmite.requiredProperty =
             RuleDefinitions.AdditionalDamageRequiredProperty.MeleeWeapon;
+    }
+    
+    /**
+     * Makes Divine Smite use correct number of dice when spending slot level 5+.
+     * Base game has config only up to level 4 slots, which leads to it using 1 die if level 5+ slot is spent.
+     */
+    private static void FixDivineSmiteDiceNumberWhenUsingHighLevelSlots()
+    {
+        DatabaseHelper.FeatureDefinitionAdditionalDamages.AdditionalDamagePaladinDivineSmite.diceByRankTable =
+            DiceByRankMaker.MakeBySteps();
     }
 
     /**


### PR DESCRIPTION
Base game has config only up to level 4 slots, which leads to it using 1 die if level 5+ slot is spent.