### PR TITLE
Fix for Produce Flame with Warcaster

### DIFF
--- a/SolastaCommunityExpansion/Api/Extensions/RulesetCharacterExension.cs
+++ b/SolastaCommunityExpansion/Api/Extensions/RulesetCharacterExension.cs
@@ -36,16 +36,20 @@ internal static class RulesetCharacterExension
 
     public static bool CanCastCantrip(
         this RulesetCharacter character,
-        SpellDefinition spellDefinition,
+        SpellDefinition cantrip,
         out RulesetSpellRepertoire spellRepertoire)
     {
         spellRepertoire = null;
         foreach (var reperoire in character.spellRepertoires)
         {
-            if (reperoire.HasKnowledgeOfSpell(spellDefinition))
+            foreach (var knownCantrip in reperoire.KnownCantrips)
             {
-                spellRepertoire = reperoire;
-                return true;
+                if (knownCantrip == cantrip
+                    || (knownCantrip.SpellsBundle && knownCantrip.SubspellsList.Contains(cantrip)))
+                {
+                    spellRepertoire = reperoire;
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
reworked `CanCastCantrip` to properly account for bundled cantrips (like Produce Flame)