### PR TITLE
Dark elf tweaks

### DIFF
--- a/SolastaCommunityExpansion/Races/Darkelf.cs
+++ b/SolastaCommunityExpansion/Races/Darkelf.cs
@@ -114,31 +114,61 @@ internal static class DarkelfRaceBuilder
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(FaceAndSkin_01, "DarkelfSkin2", "d26c8ce0-884f-4abd-90fd-dc961802c48b")
-            .SetMainColor(HairColorBlack.MainColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.129411765f,
+                g = 0.188235294f,
+                b = 0.239215686f,
+                a = 1.0f,
+            })
             .SetSortOrder(49)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(FaceAndSkin_01, "DarkelfSkin3", "d26c8ce0-884f-4abd-90fd-dc961802c48c")
-            .SetMainColor(HairColor_43.MainColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.188235294f,
+                g = 0.258823529f,
+                b = 0.317647059f,
+                a = 1.0f,
+            })
             .SetSortOrder(50)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(FaceAndSkin_01, "DarkelfSkin4", "d26c8ce0-884f-4abd-90fd-dc961802c48d")
-            .SetMainColor(BodyDecorationColor_Default_00.SecondColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.266666667f,
+                g = 0.360784314f,
+                b = 0.439215687f,
+                a = 1.0f,
+            })
             .SetSortOrder(51)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(FaceAndSkin_01, "DarkelfSkin5", "d26c8ce0-884f-4abd-90fd-dc961802c48e")
-            .SetMainColor(HairColorBlack.SecondColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.164705882f,
+                g = 0.184313725f,
+                b = 0.239215686f,
+                a = 1.0f,
+            })
             .SetSortOrder(52)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(FaceAndSkin_01, "DarkelfSkin6", "d26c8ce0-884f-4abd-90fd-dc961802c48f")
-            .SetMainColor(HairColor_43.SecondColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.054901961f,
+                g = 0.007843137f,
+                b = 0.015686274f,
+                a = 1.0f,
+            })
             .SetSortOrder(53)
             .AddToDB();
 

--- a/SolastaCommunityExpansion/Races/Darkelf.cs
+++ b/SolastaCommunityExpansion/Races/Darkelf.cs
@@ -180,31 +180,61 @@ internal static class DarkelfRaceBuilder
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(HairColorSilver, "DarkelfHair2", "7dd1a932-69d3-4d51-b9c6-eccaaed90008")
-            .SetMainColor(FaceAndSkin_Neutral.SecondColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.945098039f,
+                g = 0.952941176f,
+                b = 0.980392157f,
+                a = 1.0f,
+            })
             .SetSortOrder(49)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(HairColorSilver, "DarkelfHair3", "7dd1a932-69d3-4d51-b9c6-eccaaed90009")
-            .SetMainColor(HairColorBlue.MainColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.890196078f,
+                g = 0.933333333f,
+                b = 0.976470588f,
+                a = 1.0f,
+            })
             .SetSortOrder(50)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(HairColorSilver, "DarkelfHair4", "7dd1a932-69d3-4d51-b9c6-eccaaed90010")
-            .SetMainColor(HairColorBlue.SecondColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.870588235f,
+                g = 0.894117647f,
+                b = 0.925490196f,
+                a = 1.0f,
+            })
             .SetSortOrder(51)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(HairColorSilver, "DarkelfHair5", "7dd1a932-69d3-4d51-b9c6-eccaaed90011")
-            .SetMainColor(HairColorSilver.MainColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.968627451f,
+                g = 0.929411765f,
+                b = 0.937254902f,
+                a = 1.0f,
+            })
             .SetSortOrder(52)
             .AddToDB();
 
         _ = MorphotypeElementDefinitionBuilder
             .Create(HairColorSilver, "DarkelfHair6", "7dd1a932-69d3-4d51-b9c6-eccaaed90012")
-            .SetMainColor(HairColorSilver.SecondColor)
+            .SetMainColor(new UnityEngine.Color()
+            {
+                r = 0.996078431f,
+                g = 0.913725490f,
+                b = 0.913725490f,
+                a = 1.0f,
+            })
             .SetSortOrder(53)
             .AddToDB();
 

--- a/SolastaCommunityExpansion/Translations/en/DarkElves-en.txt
+++ b/SolastaCommunityExpansion/Translations/en/DarkElves-en.txt
@@ -11,9 +11,9 @@ Feature/&DarkelfWeaponTrainingTitle	Dark Elf Weapon Training
 Feature/&LightAffinityDarkelfLightSensitivityDescription	You have disadvantage on attack rolls and Wisdom (Perception) checks in bright light.
 Feature/&LightAffinityDarkelfLightSensitivityTitle	Sunlight Sensitivity
 Feature/&PowerDarkelfDarknessDescription	Create an area of magical darkness. Usable once per long rest.
-Feature/&PowerDarkelfDarknessTitle	Feyshadow
+Feature/&PowerDarkelfDarknessTitle	Darkness
 Feature/&PowerDarkelfFaerieFireDescription	Highlight creatures to give advantage to anyone attacking them. Usable once per long rest.
-Feature/&PowerDarkelfFaerieFireTitle	Feyfire
+Feature/&PowerDarkelfFaerieFireTitle	Faerie Fire
 Race/&DarkelfRaceDescription	Dark elves are descendants of elves that have been changed over time by living in the inhospitable Badlands. Dark elves are largely nocturnal and have become adapted to living in ancient Badlands ruins, especially buried underground ruins. They tend to have dark skin and pale hair.
 Race/&DarkelfRaceTitle	Dark Elf
 Race/&DarkelfSurName1Title	Za'Moryra


### PR DESCRIPTION
Custom skin colors and hair colors. Hair colors are a range of "whites". Also updated translations to rename the powers to match the spells since they can now be granted at the appropriate levels and no longer need any modifications to make them first level abilities.