### PR TITLE
Dark elf tweaks

### DIFF
--- a/SolastaCommunityExpansion/Races/Darkelf.cs
+++ b/SolastaCommunityExpansion/Races/Darkelf.cs
@@ -31,15 +31,21 @@ internal static class DarkelfRaceBuilder
             .Create("AbilityCheckAffinityDarkelfLightSensitivity", "a4f82743-0d75-4178-ba25-b3707420e17e")
             .SetGuiPresentation(Category.Feature)
             .BuildAndSetAffinityGroups(
-                RuleDefinitions.CharacterAbilityCheckAffinity.Disadvantage, RuleDefinitions.DieType.D1, 0,
+                RuleDefinitions.CharacterAbilityCheckAffinity.None, RuleDefinitions.DieType.D1, -2,
                 (AttributeDefinitions.Wisdom, SkillDefinitions.Perception))
             .AddToDB();
         darkElfPerception.AffinityGroups[0].lightingContext = RuleDefinitions.LightingContext.BrightLight;
 
+        var darkelfMovementAffinty = FeatureDefinitionMovementAffinityBuilder
+            .Create(FeatureDefinitionMovementAffinitys.MovementAffinityHeavyArmorOverload, "MovementAffinityDarkelfLightSensitivity", "17c4b5a2-ae5e-4565-a399-73beaaa09431")
+            .SetGuiPresentation(Category.Feature)
+            .SetBaseSpeedAdditiveModifier(-1)
+            .AddToDB();          
+
         var darkelfConditionLightSensitive = ConditionDefinitionBuilder
             .Create("ConditionDarkelfLightSensitive", "8c7cb851-6810-4101-8a6a-e932e9cc3896")
             .SetGuiPresentation(Category.Condition)
-            .SetFeatures(FeatureDefinitionCombatAffinitys.CombatAffinitySensitiveToLight, darkElfPerception)
+            .SetFeatures(darkElfPerception, darkelfMovementAffinty)
             .AddToDB();
 
         var darkelfLightingEffectAndCondition = new FeatureDefinitionLightAffinity.LightingEffectAndCondition

--- a/SolastaCommunityExpansion/Translations/en/DarkElves-en.txt
+++ b/SolastaCommunityExpansion/Translations/en/DarkElves-en.txt
@@ -8,8 +8,8 @@ Feature/&DarkelfMagicDescription	You know the Dancing Lights cantrip. At 3rd lev
 Feature/&DarkelfMagicTitle	Dark Elf Magic
 Feature/&DarkelfWeaponTrainingDescription	You have proficiency with rapiers, shortswords, and hand crossbows.
 Feature/&DarkelfWeaponTrainingTitle	Dark Elf Weapon Training
-Feature/&LightAffinityDarkelfLightSensitivityDescription	You have disadvantage on attack rolls and Wisdom (Perception) checks in bright light.
-Feature/&LightAffinityDarkelfLightSensitivityTitle	Sunlight Sensitivity
+Feature/&LightAffinityDarkelfLightSensitivityDescription	You have a -2 penalty on Wisdom (Perception) checks in bright light. In addition, your speed is reduced by 1 in bright light.
+Feature/&LightAffinityDarkelfLightSensitivityTitle	Bright Light Sensitivity
 Feature/&PowerDarkelfDarknessDescription	Create an area of magical darkness. Usable once per long rest.
 Feature/&PowerDarkelfDarknessTitle	Darkness
 Feature/&PowerDarkelfFaerieFireDescription	Highlight creatures to give advantage to anyone attacking them. Usable once per long rest.


### PR DESCRIPTION
In "light" of the fact that Solasta doesn't differentiate between bright light and sunlight, the RAW light sensitivity for Drow is just too oppressive. I have replaced them with a -2 penalty on Wisdom(Perception) checks and a -1 penalty to movement speed in bright light. Still thematic and enough of a negative to notice, but should be much less painful and therefore hopefully more fun to play. FYI - I also noticed that whether you have Dark Elf enabled in settings or not, they are always visible and selectable ever since they were moved to a subrace. I haven't figured out how to fix that. It probably needs someone more code savvy to look at it...