### PR TITLE
Change Soulblade's Soul Empower to Free Action

### DIFF
--- a/SolastaCommunityExpansion/Classes/Warlock/Subclasses/AHWarlockSubclassSoulBlade.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Subclasses/AHWarlockSubclassSoulBlade.cs
@@ -76,7 +76,7 @@ public static class AHWarlockSubclassSoulBladePact
             .SetRechargeRate(RechargeRate.LongRest)
             .SetFixedUsesPerRecharge(1)
             .SetCostPerUse(1)
-            .SetActivationTime(ActivationTime.Action)
+            .SetActivationTime(ActivationTime.NoCost)
             .SetAttackModifierAbility(true, true, AttributeDefinitions.Charisma)
             .SetEffectDescription(new EffectDescriptionBuilder()
                 .SetDurationData(DurationType.UntilLongRest)


### PR DESCRIPTION
## The problem

- Soul Empower is a feature designed to be used right after a long rest. However, while travelling, it is not possible to use it right after each long rest, making your first turn on a road combat be subpar, which is even more problematic when your party is surprised or asleep

## The solution

- Chaging Soul Empower's cost to a Free Action is a nice QoL, since you're expected to use it right after each long rest anyway, so the Action cost wasn't usually meaningful, except on the scenario described above