### PR TITLE
fix for MP desync caused by toggling Force Preferred Cantrip

### DIFF
--- a/SolastaCommunityExpansion/Models/CustomReactionsContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomReactionsContext.cs
@@ -15,7 +15,8 @@ public static class CustomReactionsContext
 {
     private static IDamagedReactionSpell _alwayseact;
 
-    public static bool ForcePreferredCantrip = false;
+    public static bool ForcePreferredCantrip = false;   //used by actual feature
+    public static bool ForcePreferredCantripUI = false; //used for local UI state
     public static IDamagedReactionSpell AlwaysReactToDamaged => _alwayseact ??= new AlwaysReactToDamagedImpl();
 
     public static void Load()
@@ -125,7 +126,7 @@ public static class CustomReactionsContext
     {
         if (actionParams != null && readyActionType == ReadyActionType.Cantrip)
         {
-            actionParams.BoolParameter4 = ForcePreferredCantrip;
+            actionParams.BoolParameter4 = ForcePreferredCantripUI;
         }
     }
 

--- a/SolastaCommunityExpansion/Models/CustomReactionsContext.cs
+++ b/SolastaCommunityExpansion/Models/CustomReactionsContext.cs
@@ -120,6 +120,23 @@ public static class CustomReactionsContext
         }
     }
 
+    internal static void SaveReadyActionPreferedCantripPatch(CharacterActionParams actionParams,
+        ReadyActionType readyActionType)
+    {
+        if (actionParams != null && readyActionType == ReadyActionType.Cantrip)
+        {
+            actionParams.BoolParameter4 = ForcePreferredCantrip;
+        }
+    }
+
+    internal static void ReadReadyActionPreferedCantripPatch(CharacterActionParams actionParams)
+    {
+        if (actionParams is {ReadyActionType: ReadyActionType.Cantrip})
+        {
+            ForcePreferredCantrip = actionParams.BoolParameter4;
+        }
+    }
+
     public interface IDamagedReactionSpell
     {
         bool CanReact(GameLocationCharacter attacker, GameLocationCharacter defender, ActionModifier attackModifier,

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/ReadyActionSelectionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/ReadyActionSelectionPanelPatcher.cs
@@ -50,7 +50,7 @@ internal static class ReadyActionSelectionPanel_Bind
             toggle.PersonalityFlagDefinition = DatabaseHelper.PersonalityFlagDefinitions.Authority;
             toggle.PersonalityFlagSelected = (_, state) =>
             {
-                CustomReactionsContext.ForcePreferredCantrip = state;
+                CustomReactionsContext.ForcePreferredCantripUI = state;
                 tooltip.Content = "UI/&ForcePreferredCantripDescription";
             };
         }
@@ -59,7 +59,7 @@ internal static class ReadyActionSelectionPanel_Bind
             toggle = parent.FindChildRecursive("ForcePreferredToggle").GetComponent<PersonalityFlagToggle>();
         }
 
-        toggle.Refresh(CustomReactionsContext.ForcePreferredCantrip, true);
+        toggle.Refresh(CustomReactionsContext.ForcePreferredCantripUI, true);
         toggle.tooltip.Content = "UI/&ForcePreferredCantripDescription";
     }
 }

--- a/SolastaCommunityExpansion/Patches/Insertion/CharacterActionPanelPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Insertion/CharacterActionPanelPatcher.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaCommunityExpansion.Models;
+
+namespace SolastaCommunityExpansion.Patches.Insertion;
+
+internal static class CharacterActionPanelPatcher
+{
+    [HarmonyPatch(typeof(CharacterActionPanel), "ReadyActionEngaged")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class ReadyActionEngaged
+    {
+        internal static void Prefix(CharacterActionPanel __instance, ActionDefinitions.ReadyActionType readyActionType)
+        {
+            CustomReactionsContext.SaveReadyActionPreferedCantripPatch(__instance.actionParams, readyActionType);
+        }
+    }
+}

--- a/SolastaCommunityExpansion/Patches/Insertion/CharacterActionReadyPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Insertion/CharacterActionReadyPatcher.cs
@@ -8,7 +8,7 @@ internal static class CharacterActionReadyPatcher
 {
     [HarmonyPatch(typeof(CharacterActionReady), "ExecuteImpl")]
     [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
-    internal static class ReadyActionEngaged
+    internal static class ExecuteImpl
     {
         internal static void Prefix(CharacterActionReady __instance)
         {

--- a/SolastaCommunityExpansion/Patches/Insertion/CharacterActionReadyPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/Insertion/CharacterActionReadyPatcher.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using SolastaCommunityExpansion.Models;
+
+namespace SolastaCommunityExpansion.Patches.Insertion;
+
+internal static class CharacterActionReadyPatcher
+{
+    [HarmonyPatch(typeof(CharacterActionReady), "ExecuteImpl")]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    internal static class ReadyActionEngaged
+    {
+        internal static void Prefix(CharacterActionReady __instance)
+        {
+            CustomReactionsContext.ReadReadyActionPreferedCantripPatch(__instance.actionParams);
+        }
+    }
+}


### PR DESCRIPTION
store `ForcePreferredCantrip`'s value in the `BoolParameter4` of the action when it is activated and read from it on execution - this should fix MP desync caused by toggling Force Preferred Cantrip.
Tested it still working in SP, haven't tested it in the MP.