### PR TITLE
change titles of valley nobles clothes to match color

### DIFF
--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -66,6 +66,31 @@ internal static class ItemOptionsContext
 
             Store_Merchant_Gorim_Ironsoot_Cyflen_GeneralStore.StockUnitDescriptions.Add(stockClothing);
         }
+
+        //rename valley noble's clothes by color to avoid confusion
+        var silverNoble = ClothesNoble_Valley_Silver;
+        silverNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Silver";
+
+        var redNoble = ClothesNoble_Valley_Red;
+        redNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Red";
+
+        var purpleNoble = ClothesNoble_Valley_Purple;
+        purpleNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Purple";
+
+        var pinkNoble = ClothesNoble_Valley_Pink;
+        pinkNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Pink";
+
+        var orangeNoble = ClothesNoble_Valley_Orange;
+        orangeNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Orange";
+
+        var greenNoble = ClothesNoble_Valley_Green;
+        greenNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Green";
+
+        var cherryNoble = ClothesNoble_Valley_Cherry;
+        cherryNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Cherry";
+
+        var valleyNoble = ClothesNoble_Valley;
+        valleyNoble.GuiPresentation.title = "Equipment/&Armor_Noble_ClothesTitle_Valley";
     }
 
     internal static void SwitchSetBeltOfDwarvenKindBeardChances()

--- a/SolastaCommunityExpansion/Translations/en/ItemsCrafting-en.txt
+++ b/SolastaCommunityExpansion/Translations/en/ItemsCrafting-en.txt
@@ -1,3 +1,11 @@
+Equipment/&Armor_Noble_ClothesTitle_Cherry=Cherry Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Green=Green Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Orange=Orange Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Pink=Pink Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Purple=Purple Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Red=Red Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Silver=Silver Noble's Clothes
+Equipment/&Armor_Noble_ClothesTitle_Valley=Valley Noble's Clothes
 Equipment/&CEHalberdTypeTitle=Halberds
 Equipment/&CEHandXbowTypeTitle=Hand Crossbows
 Equipment/&CELongMaceTypeTitle=Long Maces


### PR DESCRIPTION
When added to Gorim's stock, the new noble clothes from the Lost Valley DLC look like duplicates because TA gave them all the same title. I created new titles to indicate their colors.