### PR TITLE
Arcane shieldstaff attunement options

### DIFF
--- a/SolastaCommunityExpansion/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Displays/RulesDisplay.cs
@@ -162,8 +162,6 @@ internal static class RulesDisplay
 
         UI.Label("");
 
-        UI.Label("");
-
         using (UI.HorizontalScope())
         {
             UI.Label(Gui.Localize("ModUi/&ArcaneShieldstaffOptions"), UI.AutoWidth());
@@ -177,6 +175,8 @@ internal static class RulesDisplay
                 ItemOptionsContext.SwitchAttuneArcaneShieldstaff();
             }
         }
+
+        UI.Label("");
 
         var intValue = Main.Settings.IncreaseSenseNormalVision;
         UI.Label(Gui.Localize("ModUi/&IncreaseSenseNormalVision"));

--- a/SolastaCommunityExpansion/Displays/RulesDisplay.cs
+++ b/SolastaCommunityExpansion/Displays/RulesDisplay.cs
@@ -1,4 +1,5 @@
-﻿using ModKit;
+﻿using System;
+using ModKit;
 using SolastaCommunityExpansion.Models;
 using SolastaCommunityExpansion.Spells;
 
@@ -8,6 +9,8 @@ internal static class RulesDisplay
 {
     internal static void DisplayRules()
     {
+        int intValue2;
+
         UI.Label("");
         UI.Label(Gui.Localize("ModUi/&SRD"));
         UI.Label("");
@@ -158,6 +161,22 @@ internal static class RulesDisplay
         }
 
         UI.Label("");
+
+        UI.Label("");
+
+        using (UI.HorizontalScope())
+        {
+            UI.Label(Gui.Localize("ModUi/&ArcaneShieldstaffOptions"), UI.AutoWidth());
+
+            intValue2 = Array.IndexOf(ItemOptionsContext.ArcaneShieldstaffOptions,
+                Main.Settings.ArcaneShieldstaffOptions);
+            if (UI.SelectionGrid(ref intValue2, ItemOptionsContext.ArcaneShieldstaffOptions,
+                    ItemOptionsContext.ArcaneShieldstaffOptions.Length, 3, UI.AutoWidth()))
+            {
+                Main.Settings.ArcaneShieldstaffOptions = ItemOptionsContext.ArcaneShieldstaffOptions[intValue2];
+                ItemOptionsContext.SwitchAttuneArcaneShieldstaff();
+            }
+        }
 
         var intValue = Main.Settings.IncreaseSenseNormalVision;
         UI.Label(Gui.Localize("ModUi/&IncreaseSenseNormalVision"));

--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -21,6 +21,11 @@ internal static class ItemOptionsContext
         "Studded Leather", "Sylvan Armor", "Wizard Clothes"
     };
 
+    internal static readonly string[] ArcaneShieldstaffOptions =
+    {
+        "Default Classes", "Add Druid and Sorcerer", "Add All Classes"
+    };
+
     private static readonly List<ItemDefinition> Crowns = new()
     {
         CrownOfTheMagister,
@@ -238,6 +243,24 @@ internal static class ItemOptionsContext
         }
     }
 
+    internal static void SwitchAttuneArcaneShieldstaff()
+    {
+        switch (Main.Settings.ArcaneShieldstaffOptions)
+        {
+            case "Default Classes":
+                break;
+
+            case "Add Druid and Sorcerer":
+                ArcaneShieldstaff.RequiredAttunementClasses.Clear();
+                ArcaneShieldstaff.RequiredAttunementClasses.AddRange(WandOfLightningBolts.RequiredAttunementClasses);
+                break;
+
+            case "Add All Classes":
+                ArcaneShieldstaff.RequiredAttunementClasses.Clear();
+                break;
+        }
+    }
+
     internal static void SwitchRestockAntiquarian()
     {
         if (!Main.Settings.RestockAntiquarians)
@@ -345,6 +368,7 @@ internal static class ItemOptionsContext
         SwitchRestockCircleOfDanantar();
         SwitchRestockTowerOfKnowledge();
         SwitchUniversalSylvanArmorAndLightbringer();
+        SwitchAttuneArcaneShieldstaff();
     }
 
     private sealed class WandIdentifyBuilder : ItemDefinitionBuilder

--- a/SolastaCommunityExpansion/Translations/en/Modui-en.txt
+++ b/SolastaCommunityExpansion/Translations/en/Modui-en.txt
@@ -19,6 +19,7 @@ ModUi/&AllowUnmarkedSorcerers=Allow <color=#D89555>Sorcerer</color> without orig
 ModUi/&AllRecipesInDm=All recipes in DM
 ModUi/&AltOnlyHighlightItemsInPartyFieldOfView=<color=#1E81B0>ALT</color> key only highlight gadgets in party field of view <i><color=#F0DAA0>[only in custom dungeons]</color></i>
 ModUi/&ApplySRDWeightToFoodRations=Reduce weight of food ration to 2 pounds
+ModUi/&ArcaneShieldstaffOptions=<color=#D89555>Arcane Shieldstaff</color> attunement options <b><i><color=#C04040E0>[Default Requires Restart]</color></i></b>:
 ModUi/&AutoPauseOnVictory=Pause the UI when victorious in battle
 ModUi/&Basic=<color=#F0DAA0>Basic:</color>
 ModUi/&Battle=<color=#F0DAA0>Battle:</color>

--- a/SolastaCommunityExpansion/Utils/Settings.cs
+++ b/SolastaCommunityExpansion/Utils/Settings.cs
@@ -163,6 +163,7 @@ public class Settings : UnityModManager.ModSettings
     public bool AllowDruidToWearMetalArmor { get; set; }
     public bool DisableAutoEquip { get; set; }
     public bool MakeAllMagicStaveArcaneFoci { get; set; }
+    public string ArcaneShieldstaffOptions { get; set; } = "Add Druid and Sorcerer";
     public int IncreaseSenseNormalVision { get; set; } = HouseFeatureContext.DefaultVisionRange;
 
     public bool QuickCastLightCantripOnWornItemsFirst { get; set; }


### PR DESCRIPTION
Adds three options for the Arcane Shieldstaff's attunement class requirements: "Default Classes", "Add Druid and Sorcerer", "Add All Classes". Add Druid and Sorcerer is initially selected by default.