### PR TITLE
minor display tweaks, no restart needed

### DIFF
--- a/SolastaCommunityExpansion/Classes/Warlock/Warlock.cs
+++ b/SolastaCommunityExpansion/Classes/Warlock/Warlock.cs
@@ -274,7 +274,6 @@ public static class Warlock
         {
             ItemDefinitions.WandOfLightningBolts,
             ItemDefinitions.StaffOfFire,
-            ItemDefinitions.ArcaneShieldstaff,
             ItemDefinitions.WizardClothes_Alternate
         };
 

--- a/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
+++ b/SolastaCommunityExpansion/Models/ItemOptionsContext.cs
@@ -21,8 +21,8 @@ internal static class ItemOptionsContext
         "Studded Leather", "Sylvan Armor", "Wizard Clothes"
     };
 
-    internal const string ArcaneShieldDefault = "Default";
-    private const string ArcaneShieldAddDruidAndSorcerer = "Add Druid and Sorcerer";
+    internal const string ArcaneShieldDefault = "None(Default)";
+    private const string ArcaneShieldAddDruidAndSorcerer = "Druid & Sorcerer";
     private const string ArcaneShieldAll = "All";
 
     internal static readonly string[] ArcaneShieldstaffOptions =
@@ -252,11 +252,25 @@ internal static class ItemOptionsContext
         switch (Main.Settings.ArcaneShieldstaffOptions)
         {
             case ArcaneShieldDefault:
-                ArcaneShieldstaff.RequiredAttunementClasses.SetRange(Wizard, Cleric, Paladin, Ranger);
+                if (!Main.Settings.ClassEnabled.Contains(Classes.Warlock.Warlock.ClassWarlock.Name))
+                {
+                    ArcaneShieldstaff.RequiredAttunementClasses.SetRange(Wizard, Cleric, Paladin, Ranger);
+                }
+                else
+                {
+                    ArcaneShieldstaff.RequiredAttunementClasses.SetRange(Wizard, Cleric, Paladin, Ranger, Classes.Warlock.Warlock.ClassWarlock);
+                }                
                 break;
 
             case ArcaneShieldAddDruidAndSorcerer:
-                ArcaneShieldstaff.RequiredAttunementClasses.SetRange(Wizard, Cleric, Paladin, Ranger, Druid, Sorcerer);
+                if (!Main.Settings.ClassEnabled.Contains(Classes.Warlock.Warlock.ClassWarlock.Name))
+                {
+                    ArcaneShieldstaff.RequiredAttunementClasses.SetRange(Wizard, Cleric, Paladin, Ranger, Druid, Sorcerer);
+                }
+                else
+                {
+                    ArcaneShieldstaff.RequiredAttunementClasses.SetRange(Wizard, Cleric, Paladin, Ranger, Druid, Sorcerer, Classes.Warlock.Warlock.ClassWarlock);
+                }             
                 break;
 
             case ArcaneShieldAll:

--- a/SolastaCommunityExpansion/Translations/en/Modui-en.txt
+++ b/SolastaCommunityExpansion/Translations/en/Modui-en.txt
@@ -19,7 +19,7 @@ ModUi/&AllowUnmarkedSorcerers=Allow <color=#D89555>Sorcerer</color> without orig
 ModUi/&AllRecipesInDm=All recipes in DM
 ModUi/&AltOnlyHighlightItemsInPartyFieldOfView=<color=#1E81B0>ALT</color> key only highlight gadgets in party field of view <i><color=#F0DAA0>[only in custom dungeons]</color></i>
 ModUi/&ApplySRDWeightToFoodRations=Reduce weight of food ration to 2 pounds
-ModUi/&ArcaneShieldstaffOptions=<color=#D89555>Arcane Shieldstaff</color> attunement options:\n<b><i><color=#C04040E0>[Default Requires Restart]</color></i></b>
+ModUi/&ArcaneShieldstaffOptions=<color=#D89555>Arcane Shieldstaff</color> Add classes:
 ModUi/&AutoPauseOnVictory=Pause the UI when victorious in battle
 ModUi/&Basic=<color=#F0DAA0>Basic:</color>
 ModUi/&Battle=<color=#F0DAA0>Battle:</color>


### PR DESCRIPTION
Remove restart required warning. Change wording to better fit buttons. Move adding Warlock from Warlock.cs to ItemOptionsContext.cs and only attempt to add if Warlock is enabled.