### PR TITLE
Smite slot fix

### DIFF
--- a/SolastaCommunityExpansion/CustomUI/ReactionRequestSpendSpellSlotExtended.cs
+++ b/SolastaCommunityExpansion/CustomUI/ReactionRequestSpendSpellSlotExtended.cs
@@ -74,8 +74,6 @@ public sealed class ReactionRequestSpendSpellSlotExtended : ReactionRequest
 
     public override void SelectSubOption(int option)
     {
-        Main.Logger.Log(
-            $"SelectSubOption: character: '{ReactionParams.ActingCharacter?.Name}', option: {option}, items: [{string.Join(", ", SubOptionsAvailability.Select(e => $"{e.Key}:{e.Value}"))}]");
         ReactionParams.IntParameter = SubOptionsAvailability.Keys.ToList()[option];
     }
 }

--- a/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/CharacterReactionItemPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/CustomFeatures/CustomReactions/CharacterReactionItemPatcher.cs
@@ -70,3 +70,28 @@ internal static class CharacterReactionItem_Bind
         }
     }
 }
+
+// Replace `GetSelectedSubItem` to fix reaction selection crashes.
+// Default one selects last item thatr is Selected, regardless if it is active or not, leading to wrong spell slots for smites being selected
+// This implementation returns first item that is both Selected and active 
+[HarmonyPatch(typeof(CharacterReactionItem), "GetSelectedSubItem")]
+[SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+internal static class CharacterReactionItem_GetSelectedSubItem
+{
+    internal static bool Prefix(CharacterReactionItem __instance, out int __result)
+    {
+        __result = 0;
+        var itemsTable = __instance.subItemsTable;
+        for (var index = 0; index < itemsTable.childCount; ++index)
+        {
+            var item = itemsTable.GetChild(index).GetComponent<CharacterReactionSubitem>();
+            if (item.gameObject.activeSelf && item.Selected)
+            {
+                __result = index;
+                break;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes crashes that sometimes happen when reaction with sub options (smites, warcaster). Was caused by reaction sub-items not being properly disposed of and code selecting last selected item, regardless of it being active.