### PR TITLE
suppress `Class Never Instantiated` warnings on some builders instead of making them abstract

### DIFF
--- a/SolastaCommunityExpansion/CustomDefinitions/CustomFeatureDefinitionSet.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/CustomFeatureDefinitionSet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using SolastaCommunityExpansion.Api;
@@ -87,7 +88,8 @@ public class FeatureDefinitionFeatureSetCustom : FeatureDefinition
     }
 }
 
-public abstract class FeatureDefinitionFeatureSetCustomBuilder : FeatureDefinitionBuilder<
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+public class FeatureDefinitionFeatureSetCustomBuilder : FeatureDefinitionBuilder<
     FeatureDefinitionFeatureSetCustom,
     FeatureDefinitionFeatureSetCustomBuilder>
 {
@@ -254,7 +256,8 @@ public sealed class FeatureDefinitionFeatureSetReplaceCustom : FeatureDefinition
     }
 }
 
-public abstract class FeatureDefinitionFeatureSetReplaceCustomBuilder : FeatureDefinitionBuilder<
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+public class FeatureDefinitionFeatureSetReplaceCustomBuilder : FeatureDefinitionBuilder<
     FeatureDefinitionFeatureSetReplaceCustom, FeatureDefinitionFeatureSetReplaceCustomBuilder>
 {
     protected FeatureDefinitionFeatureSetReplaceCustomBuilder(string name, Guid namespaceGuid) : base(name,

--- a/SolastaCommunityExpansion/CustomDefinitions/CustomFightingStyle.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/CustomFightingStyle.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 using SolastaCommunityExpansion.Builders;
 using SolastaCommunityExpansion.CustomInterfaces;
 
@@ -21,7 +22,8 @@ public sealed class FightingStyleDefinitionCustomizable : FightingStyleDefinitio
     }
 }
 
-public abstract class CustomizableFightingStyleBuilder : FightingStyleDefinitionBuilder<
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+public class CustomizableFightingStyleBuilder : FightingStyleDefinitionBuilder<
     FightingStyleDefinitionCustomizable,
     CustomizableFightingStyleBuilder>
 {

--- a/SolastaCommunityExpansion/CustomDefinitions/FeatDefinitionWithPrerequisites.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/FeatDefinitionWithPrerequisites.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using SolastaCommunityExpansion.Builders;
 
 namespace SolastaCommunityExpansion.CustomDefinitions;
 
-internal abstract class FeatDefinitionWithPrerequisitesBuilder : FeatDefinitionBuilder<FeatDefinitionWithPrerequisites,
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+internal class FeatDefinitionWithPrerequisitesBuilder : FeatDefinitionBuilder<FeatDefinitionWithPrerequisites,
     FeatDefinitionWithPrerequisitesBuilder>
 {
     protected FeatDefinitionWithPrerequisitesBuilder(string name, Guid namespaceGuid) : base(name, namespaceGuid)

--- a/SolastaCommunityExpansion/CustomDefinitions/FeatureDefinitionAttackDisadvantageAgainstNonSource.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/FeatureDefinitionAttackDisadvantageAgainstNonSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using SolastaCommunityExpansion.Builders.Features;
@@ -52,7 +53,8 @@ public sealed class FeatureDefinitionAttackDisadvantageAgainstNonSource : Featur
     }
 }
 
-internal abstract class FeatureDefinitionAttackDisadvantageAgainstNonSourceBuilder
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+internal class FeatureDefinitionAttackDisadvantageAgainstNonSourceBuilder
     : FeatureDefinitionBuilder<FeatureDefinitionAttackDisadvantageAgainstNonSource,
         FeatureDefinitionAttackDisadvantageAgainstNonSourceBuilder>
 {

--- a/SolastaCommunityExpansion/CustomDefinitions/FeatureDefinitionOpportunityAttackImmunityIfAttackerHasCondition.cs
+++ b/SolastaCommunityExpansion/CustomDefinitions/FeatureDefinitionOpportunityAttackImmunityIfAttackerHasCondition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using SolastaCommunityExpansion.Builders.Features;
@@ -47,7 +48,8 @@ public sealed class FeatureDefinitionOpportunityAttackImmunityIfAttackerHasCondi
     }
 }
 
-internal abstract class FeatureDefinitionOpportunityAttackImmunityIfAttackerHasConditionBuilder
+[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+internal class FeatureDefinitionOpportunityAttackImmunityIfAttackerHasConditionBuilder
     : FeatureDefinitionBuilder<FeatureDefinitionOpportunityAttackImmunityIfAttackerHasCondition,
         FeatureDefinitionOpportunityAttackImmunityIfAttackerHasConditionBuilder>
 {


### PR DESCRIPTION
Abstract builders cause game to crash on startup, since they can't be instrantiated