### PR TITLE
Item context should be loaded after classes context.

### DIFF
--- a/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
+++ b/SolastaCommunityExpansion/Patches/GameManagerPatcher.cs
@@ -63,9 +63,6 @@ internal static class GameManager_BindPostDatabase
         RespecContext.Load();
         ShieldStrikeContext.Load();
 
-        // Item Options must be loaded after Item Crafting
-        ItemOptionsContext.Load();
-
         // Fighting Styles must be loaded before feats to allow feats to generate corresponding fighting style ones.
         FightingStyleContext.Load();
 
@@ -89,6 +86,9 @@ internal static class GameManager_BindPostDatabase
 
         // Load SRD and House rules last in case they change previous blueprints
         SrdAndHouseRulesContext.Load();
+        
+        // Item Options must be loaded after Item Crafting
+        ItemOptionsContext.Load();
 
         ServiceRepository.GetService<IRuntimeService>().RuntimeLoaded += _ =>
         {


### PR DESCRIPTION
### Problem:
- Allow light bringer clothe usable by any class clear `RequiredAttunementClasses` list
- Warlock add itself to `RequiredAttunementClasses`
-> Consequence is only warlock can use light bringer clothes sylvan armor.

### Fix:
- Load item context after classes context.

### Test:
- Create a wizard and add item cloth and sylvan armor into his inventory and check if the wizard can attune to both.


