### PR TITLE
Fixed Ranger Arcanist bug of never removing Arcane Mark

### DIFF
--- a/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
+++ b/SolastaCommunityExpansion/Subclasses/Ranger/Arcanist.cs
@@ -98,7 +98,7 @@ internal sealed class Arcanist : AbstractSubclass
             .SetSpecificDamageType(RuleDefinitions.DamageTypeForce)
             .SetDamageDice(RuleDefinitions.DieType.D6, 0)
             .SetNotificationTag("ArcanistMark")
-            .SetTriggerCondition(RuleDefinitions.AdditionalDamageTriggerCondition.AlwaysActive)
+            .SetTargetCondition(MarkedByArcanist, RuleDefinitions.AdditionalDamageTriggerCondition.TargetDoesNotHaveCondition)
             .SetNoSave()
             .SetNoAdvancement()
             .SetConditionOperations(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/85649507/181836143-d0807a10-1a41-4fd1-a375-b9b5dbe3398f.png)

Fixed Ranger Arcanist being overly OP by not removing mark. Added a condition where the Mark cannot be present to adding the mark, looks like newer versions of Solasta changed some processing order.

Downside: Doesn't look like the "Doesnt Have Condition" will apply only to character owned conditions, so multiple arcanists in a party would conflict.